### PR TITLE
Replace `render nothing: true` with JSON Response

### DIFF
--- a/lib/discourse_chat/provider/slack/slack_command_controller.rb
+++ b/lib/discourse_chat/provider/slack/slack_command_controller.rb
@@ -98,7 +98,7 @@ module DiscourseChat::Provider::SlackProvider
       json = JSON.parse(params[:payload], symbolize_names: true)
       process_interactive(json)
 
-      render nothing: true, status: 200
+      render json: { text: I18n.t("chat_integration.provider.slack.transcript.loading") }
     end
 
     def process_interactive(json)


### PR DESCRIPTION
render:nothing was producing an error 500 for some reason. I think this was introduced in the rails 5 update.