### PR TITLE
FIX: Mattermost icon selection

### DIFF
--- a/lib/discourse_chat/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat/provider/mattermost/mattermost_provider.rb
@@ -44,7 +44,7 @@ module DiscourseChat
         end
 
         icon_url =
-          if !SiteSetting.chat_integration_slack_icon_url.blank?
+          if !SiteSetting.chat_integration_mattermost_icon_url.blank?
             UrlHelper.absolute(SiteSetting.chat_integration_mattermost_icon_url)
           elsif !SiteSetting.logo_small_url.blank?
             UrlHelper.absolute(SiteSetting.logo_small_url)

--- a/spec/lib/discourse_chat/provider/mattermost/mattermost_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/mattermost/mattermost_provider_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe DiscourseChat::Provider::MattermostProvider do
       expect(stub1).to have_been_requested.once
     end
 
+    it 'uses correct logo' do
+      # Defaults to small logo url
+      SiteSetting.logo_small_url = "https://some_small_logo"
+      message = described_class.mattermost_message(post, chan1)
+      expect(message[:icon_url]).to eq(SiteSetting.logo_small_url)
+
+      # If specific logo provided, use that
+      SiteSetting.chat_integration_mattermost_icon_url = "https://specific_logo"
+      message = described_class.mattermost_message(post, chan1)
+      expect(message[:icon_url]).to eq(SiteSetting.chat_integration_mattermost_icon_url)
+    end
+
     it 'handles errors correctly' do
       stub1 = stub_request(:post, "https://mattermost.blah/hook/abcd").to_return(status: 500, body: "error")
       expect(stub1).to have_been_requested.times(0)


### PR DESCRIPTION
Caused by a simple typo - it was checking for presence of the slack_icon before using the mattermost icon

Have added a test case