### PR TITLE
use SiteSetting.chat_integration_matrix_excerpt_length for the Matrix provider

### DIFF
--- a/lib/discourse_chat/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat/provider/matrix/matrix_provider.rb
@@ -47,7 +47,7 @@ module DiscourseChat
           formatted_body: I18n.t('chat_integration.provider.matrix.formatted_message',                           user: display_name,
                                                                                                                  post_url: post.full_url,
                                                                                                                  title: post.topic.title,
-                                                                                                                 excerpt: post.excerpt(SiteSetting.chat_integration_discord_excerpt_length, text_entities: true, strip_links: true, remap_emoji: true))
+                                                                                                                 excerpt: post.excerpt(SiteSetting.chat_integration_matrix_excerpt_length, text_entities: true, strip_links: true, remap_emoji: true))
 
         }
 


### PR DESCRIPTION
I recently configured the Matrix provider included in `discourse-chat-integration` on a Discourse forum I help manage and I was wondering why the "chat integration matrix excerpt length" setting didn't seem to have any effect on the excerpt length of the messages posted by the bot.

I just looked at the code of this plugin and I found a typo that explains why I was having this issue 🙂 