### PR TITLE
FEATURE: support for slack custom username

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
     #######################################
     ########## SLACK SETTINGS #############
     #######################################
+    chat_integration_slack_username: "Bot's username to post to slack with"
     chat_integration_slack_enabled: 'Enable the slack chat-integration provider'
     chat_integration_slack_access_token: 'OAuth Access Token for authenticating with Slack'
     chat_integration_slack_incoming_webhook_token: 'The verification token used to authenticate incoming requests'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,8 @@ chat_integration:
 #######################################
 ########## SLACK SETTINGS #############
 #######################################
+  chat_integration_slack_username:
+    default: Discourse
   chat_integration_slack_enabled:
     default: false
     validator: "ChatIntegrationSlackEnabledSettingValidator"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,7 @@ chat_integration:
 ########## SLACK SETTINGS #############
 #######################################
   chat_integration_slack_username:
-    default: Discourse
+    default: ''
   chat_integration_slack_enabled:
     default: false
     validator: "ChatIntegrationSlackEnabledSettingValidator"

--- a/lib/discourse_chat/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat/provider/slack/slack_provider.rb
@@ -38,9 +38,16 @@ module DiscourseChat::Provider::SlackProvider
         "#{Discourse.base_url}#{SiteSetting.logo_small_url}"
       end
 
+    slack_username =
+      if SiteSetting.chat_integration_slack_username.present?
+        SiteSetting.chat_integration_slack_username
+      else
+        SiteSetting.title || "Discourse"
+      end
+
     message = {
       channel: channel,
-      username: SiteSetting.chat_integration_slack_username || SiteSetting.title || "Discourse",
+      username: slack_username,
       icon_url: icon_url,
       attachments: []
     }

--- a/lib/discourse_chat/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat/provider/slack/slack_provider.rb
@@ -40,7 +40,7 @@ module DiscourseChat::Provider::SlackProvider
 
     message = {
       channel: channel,
-      username: SiteSetting.title || "Discourse",
+      username: SiteSetting.chat_integration_slack_username,
       icon_url: icon_url,
       attachments: []
     }

--- a/lib/discourse_chat/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat/provider/slack/slack_provider.rb
@@ -40,7 +40,7 @@ module DiscourseChat::Provider::SlackProvider
 
     message = {
       channel: channel,
-      username: SiteSetting.chat_integration_slack_username,
+      username: SiteSetting.chat_integration_slack_username || SiteSetting.title || "Discourse",
       icon_url: icon_url,
       attachments: []
     }


### PR DESCRIPTION
Adds support for custom bot's username by adding the `chat_integration_slack_username` setting to `settings.yml`. It broadens the possibilities for that _username_ since it was previously set to the site's title, and it wasn't customizable.

You can now get something like this:
![image](https://user-images.githubusercontent.com/11674283/45581210-8a3e8080-b870-11e8-9c19-2ad9fc5fca79.png)

