### PR TITLE
fix loading user.list longer than 1000

### DIFF
--- a/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
@@ -195,7 +195,7 @@ describe 'Slack Command Controller', type: :request do
 
         context "with valid slack responses" do
           before do
-            stub_request(:post, "https://slack.com/api/users.list").to_return(body: '{"ok":true,"members":[{"id":"U5Z773QLS","name":"david","profile":{"icon_24":"https://example.com/avatar"}}]}')
+            stub_request(:post, "https://slack.com/api/users.list").to_return(body: '{"ok":true,"members":[{"id":"U5Z773QLS","name":"david","profile":{"icon_24":"https://example.com/avatar"}}],"response_metadata":{"next_cursor":""}}')
             stub_request(:post, "https://slack.com/api/conversations.history").to_return(body: { ok: true, messages: messages_fixture }.to_json)
           end
 

--- a/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
   describe 'loading users' do
     it 'loads users correctly' do
       stub_request(:post, "https://slack.com/api/users.list")
-        .with(body: { token: "abcde" })
-        .to_return(status: 200, body: { ok: true, members: [{ id: "U5Z773QLS", name: "awesomeguy", profile: { image_24: "https://example.com/avatar" } }] }.to_json)
+        .with(body: { token: "abcde", "cursor": nil, "limit": "200" })
+        .to_return(status: 200, body: { ok: true, members: [{ id: "U5Z773QLS", name: "awesomeguy", profile: { image_24: "https://example.com/avatar" } }], response_metadata: { next_cursor: "" } }.to_json)
 
       expect(transcript.load_user_data).to be_truthy
     end
@@ -99,7 +99,7 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
   context 'with loaded users' do
     before do
       stub_request(:post, "https://slack.com/api/users.list")
-        .to_return(status: 200, body: { ok: true, members: [{ id: "U5Z773QLS", name: "awesomeguy", profile: { image_24: "https://example.com/avatar" } }] }.to_json)
+        .to_return(status: 200, body: { ok: true, members: [{ id: "U5Z773QLS", name: "awesomeguy", profile: { image_24: "https://example.com/avatar" } }], response_metadata: { next_cursor: "" } }.to_json)
       transcript.load_user_data
     end
 


### PR DESCRIPTION
While it's not explicitly described in [API description for users.list method](https://api.slack.com/methods/users.list) Slack returns users.list limited to 1000 members. So if we want to load longer list, we need to use [pagination](https://api.slack.com/docs/pagination)