### PR TITLE
Add Matrix option for using plain text instead of notice

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,6 +55,7 @@ en:
     chat_integration_matrix_homeserver: "Homeserver to connect to. Make sure to include the protocol"
     chat_integration_matrix_access_token: "Access token for the bot's Matrix account"
     chat_integration_matrix_excerpt_length: "Matrix post excerpt length"
+    chat_integration_matrix_use_notice: "Use notice instead of plain message"
 
     #######################################
     ########### ZULIP SETTINGS ############

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,6 +85,8 @@ chat_integration:
     default: ''
   chat_integration_matrix_excerpt_length:
     default: 400
+  chat_integration_matrix_use_notice:
+    default: true
 
 #######################################
 ########### ZULIP SETTINGS ############

--- a/lib/discourse_chat/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat/provider/matrix/matrix_provider.rb
@@ -39,7 +39,7 @@ module DiscourseChat
         end
 
         message = {
-          msgtype: 'm.notice',
+          msgtype: SiteSetting.chat_integration_matrix_use_notice ? 'm.notice' : 'm.text',
           body: I18n.t('chat_integration.provider.matrix.text_message',                           user: display_name,
                                                                                                   post_url: post.full_url,
                                                                                                   title: post.topic.title),


### PR DESCRIPTION
Notices are problematic on certain IRC clients and lead to bans if the Matrix channel is bridged to IRC.

Fixes [Change communication with Matrix from notice to message](https://meta.discourse.org/t/change-communication-with-matrix-from-notice-to-message/93874).