### PR TITLE
Use Slack display names instead of the "name" field

### DIFF
--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -38,7 +38,8 @@ module DiscourseChat::Provider::SlackProvider
         text = parts.length > 1 ? parts[1] : parts[0]
 
         if parts[0].start_with?('@')
-          user = @transcript.users.find { |u| u["id"] == parts[0].gsub('@', '') }
+          user_id = parts[0].gsub('@', '')
+          user = @transcript.users[user_id]
           next "@#{user['name']}"
         end
 
@@ -93,7 +94,7 @@ module DiscourseChat::Provider::SlackProvider
 
     def user
       return nil unless user_id = @raw["user"]
-      @transcript.users.find { |u| u["id"] == user_id }
+      @transcript.users[user_id]
     end
   end
 end

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -37,9 +37,8 @@ module DiscourseChat::Provider::SlackProvider
         text = parts.length > 1 ? parts[1] : parts[0]
 
         if parts[0].start_with?('@')
-          user_id = parts[0].gsub('@', '')
-          user = @transcript.users[user_id]
-          if user
+          user_id = parts[0][1..-1]
+          if user = @transcript.users[user_id]
             user_name = user['_transcript_username']
           else
             user_name = user_id

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -40,7 +40,12 @@ module DiscourseChat::Provider::SlackProvider
         if parts[0].start_with?('@')
           user_id = parts[0].gsub('@', '')
           user = @transcript.users[user_id]
-          next "@#{user['name']}"
+          if user
+            user_name = user["profile"]["display_name"] || user["profile"]["real_name"]
+          else
+            user_name = user_id
+          end
+          next "@#{user_name}"
         end
 
         "[#{text}](#{link})"

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -12,7 +12,7 @@ module DiscourseChat::Provider::SlackProvider
         user["_transcript_username"]
       elsif @raw.key?("username")
         # This is for bot messages
-        @raw["username"]
+        @raw["username"].gsub(' ', '_')
       end
     end
 

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -9,7 +9,7 @@ module DiscourseChat::Provider::SlackProvider
 
     def username
       if user
-        user['name']
+        user["profile"]["display_name"]
       elsif @raw.key?("username")
         @raw["username"]
       end

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -9,8 +9,7 @@ module DiscourseChat::Provider::SlackProvider
 
     def username
       if user
-        # Slack uses display_name and falls back to real_name if it is not set
-        user["profile"]["display_name"] || user["profile"]["real_name"]
+        user["_transcript_username"]
       elsif @raw.key?("username")
         # This is for bot messages
         @raw["username"]
@@ -41,7 +40,7 @@ module DiscourseChat::Provider::SlackProvider
           user_id = parts[0].gsub('@', '')
           user = @transcript.users[user_id]
           if user
-            user_name = user["profile"]["display_name"] || user["profile"]["real_name"]
+            user_name = user['_transcript_username']
           else
             user_name = user_id
           end

--- a/lib/discourse_chat/provider/slack/slack_message.rb
+++ b/lib/discourse_chat/provider/slack/slack_message.rb
@@ -9,8 +9,10 @@ module DiscourseChat::Provider::SlackProvider
 
     def username
       if user
-        user["profile"]["display_name"]
+        # Slack uses display_name and falls back to real_name if it is not set
+        user["profile"]["display_name"] || user["profile"]["real_name"]
       elsif @raw.key?("username")
+        # This is for bot messages
         @raw["username"]
       end
     end

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -210,6 +210,7 @@ module DiscourseChat::Provider::SlackProvider
           @users[user['id']] = user
         end
       end
+      return true
     end
 
     def load_chat_history(count: 500)

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -213,6 +213,7 @@ module DiscourseChat::Provider::SlackProvider
           else
             user['_transcript_username'] = user['profile']['display_name']
           end
+          user['_transcript_username'] = user['_transcript_username'].gsub(' ', '_')
           @users[user['id']] = user
         end
       end

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -197,7 +197,7 @@ module DiscourseChat::Provider::SlackProvider
       cursor = nil
       req = Net::HTTP::Post.new(URI('https://slack.com/api/users.list'))
 
-      @users = []
+      @users = {}
       loop do
         break if cursor == ""
         req.set_form_data(token: SiteSetting.chat_integration_slack_access_token, limit: 200, cursor: cursor)
@@ -206,9 +206,10 @@ module DiscourseChat::Provider::SlackProvider
         json = JSON.parse(response.body)
         return false unless json['ok']
         cursor = json['response_metadata']['next_cursor']
-        @users << json['members']
+        for user in json['members']
+          @users[user['id']] = user
+        end
       end
-      @users&.flatten!
     end
 
     def load_chat_history(count: 500)

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -216,7 +216,7 @@ module DiscourseChat::Provider::SlackProvider
           @users[user['id']] = user
         end
       end
-      return true
+      true
     end
 
     def load_chat_history(count: 500)

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -206,9 +206,9 @@ module DiscourseChat::Provider::SlackProvider
         json = JSON.parse(response.body)
         return false unless json['ok']
         cursor = json['response_metadata']['next_cursor']
-        for user in json['members']
+        json['members'].each do |user|
           # Slack uses display_name and falls back to real_name if it is not set
-          if user['profile']['display_name'].empty?
+          if user['profile']['display_name'].blank?
             user['_transcript_username'] = user['profile']['real_name']
           else
             user['_transcript_username'] = user['profile']['display_name']

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -207,6 +207,12 @@ module DiscourseChat::Provider::SlackProvider
         return false unless json['ok']
         cursor = json['response_metadata']['next_cursor']
         for user in json['members']
+          # Slack uses display_name and falls back to real_name if it is not set
+          if user['profile']['display_name'].empty?
+            user['_transcript_username'] = user['profile']['real_name']
+          else
+            user['_transcript_username'] = user['profile']['display_name']
+          end
           @users[user['id']] = user
         end
       end

--- a/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
@@ -197,7 +197,7 @@ describe 'Slack Command Controller', type: :request do
 
         context "with valid slack responses" do
           before do
-            stub_request(:post, "https://slack.com/api/users.list").to_return(body: '{"ok":true,"members":[{"id":"U5Z773QLS","name":"david","profile":{"icon_24":"https://example.com/avatar"}}],"response_metadata":{"next_cursor":""}}')
+            stub_request(:post, "https://slack.com/api/users.list").to_return(body: '{"ok":true,"members":[{"id":"U5Z773QLS","profile":{"display_name":"david","real_name":"david","icon_24":"https://example.com/avatar"}}],"response_metadata":{"next_cursor":""}}')
             stub_request(:post, "https://slack.com/api/conversations.history").to_return(body: { ok: true, messages: messages_fixture }.to_json)
           end
 

--- a/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
       {
           "type": "message",
           "user": "U5Z773QLZ",
-          "text": "Oooh a new discourse plugin???",
+          "text": "Oooh a new discourse plugin <@U5Z773QLS> ???",
           "ts": "1501801643.056375"
       },
       {
@@ -62,7 +62,7 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
         {
             "type": "message",
             "user": "U5Z773QLS",
-            "text": "Let’s try some *bold text*",
+            "text": "Let’s try some *bold text* <@U5Z773QLZ> <@someotheruser>",
             "ts": "1501093331.439776"
         },
     ]
@@ -188,7 +188,7 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
       end
 
       it 'handles bold text' do
-        expect(transcript.messages.first.text).to eq("Let’s try some **bold text**")
+        expect(transcript.messages.first.text).to start_with("Let’s try some **bold text** ")
       end
 
       it 'handles links' do
@@ -246,7 +246,16 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
         expect(transcript.messages[1].username).to eq('Test Community') # Bot user
         expect(transcript.messages[2].username).to eq(nil) # Unknown normal user
         # Normal user, display_name not set (fall back to real_name)
-        expect(transcript.messages[5].username).to eq('another guy')
+        expect(transcript.messages[4].username).to eq('another guy')
+      end
+
+      it 'handles user mentions correctly' do
+        # User with display_name not set, unrecognized user
+        expect(transcript.first_message.text).to \
+          eq('Let’s try some **bold text** @another guy @someotheruser')
+        # Normal user
+        expect(transcript.messages[4].text).to \
+          eq('Oooh a new discourse plugin @awesomeguy ???')
       end
 
       it 'handles avatars correctly' do
@@ -265,7 +274,7 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
         [quote]
         [**View in #general on Slack**](https://slack.com/archives/G1234/p1501093331439776)
 
-        ![awesomeguy] **@awesomeguy:** Let’s try some **bold text**
+        ![awesomeguy] **@awesomeguy:** Let’s try some **bold text** @another guy @someotheruser
 
         **@Test Community:** 
         > Discourse can now be integrated with Mattermost! - @david

--- a/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_transcript_spec.rb
@@ -243,16 +243,16 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
 
       it 'handles usernames correctly' do
         expect(transcript.first_message.username).to eq('awesomeguy') # Normal user
-        expect(transcript.messages[1].username).to eq('Test Community') # Bot user
+        expect(transcript.messages[1].username).to eq('Test_Community') # Bot user
         expect(transcript.messages[2].username).to eq(nil) # Unknown normal user
         # Normal user, display_name not set (fall back to real_name)
-        expect(transcript.messages[4].username).to eq('another guy')
+        expect(transcript.messages[4].username).to eq('another_guy')
       end
 
       it 'handles user mentions correctly' do
         # User with display_name not set, unrecognized user
         expect(transcript.first_message.text).to \
-          eq('Let’s try some **bold text** @another guy @someotheruser')
+          eq('Let’s try some **bold text** @another_guy @someotheruser')
         # Normal user
         expect(transcript.messages[4].text).to \
           eq('Oooh a new discourse plugin @awesomeguy ???')
@@ -274,9 +274,9 @@ RSpec.describe DiscourseChat::Provider::SlackProvider::SlackTranscript do
         [quote]
         [**View in #general on Slack**](https://slack.com/archives/G1234/p1501093331439776)
 
-        ![awesomeguy] **@awesomeguy:** Let’s try some **bold text** @another guy @someotheruser
+        ![awesomeguy] **@awesomeguy:** Let’s try some **bold text** @another_guy @someotheruser
 
-        **@Test Community:** 
+        **@Test_Community:** 
         > Discourse can now be integrated with Mattermost! - @david
 
         [/quote]


### PR DESCRIPTION
The "name" field from the Slack API is the left-hand side of the email address in many cases.  This information is not otherwise available so we shouldn't expose it in forum posts.

This will also make the transcripts more consistent with the way Slack displays usernames.

I think the automated tests will need an update, once I hear that someone is looking at PRs here I will try.