### PR TITLE
FIX: undefined local variable or method 'site_setting_saved'

### DIFF
--- a/lib/discourse_chat/provider/telegram/telegram_initializer.rb
+++ b/lib/discourse_chat/provider/telegram/telegram_initializer.rb
@@ -16,7 +16,7 @@ if Gem::Version.new(Discourse::VERSION::STRING) > Gem::Version.new("2.3.0.beta8"
     end
   end
 else
-  DiscourseEvent.on(site_setting_saved) do |sitesetting|
+  DiscourseEvent.on(:site_setting_saved) do |sitesetting|
     isEnabledSetting = sitesetting.name == 'chat_integration_telegram_enabled'
     isAccessToken =  sitesetting.name == 'chat_integration_telegram_access_token'
 


### PR DESCRIPTION
Hello,

This PR fixes the error:  `undefined local variable or method 'site_setting_saved' for main:Object (NameError)` for Discourse `v2.2.4`.

Thanks!