### PR TITLE
FIX: Save on chat_controller ready for Rails 6.0.0

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -79,7 +79,7 @@ class DiscourseChat::ChatController < ApplicationController
 
       channel = DiscourseChat::Channel.new(hash)
 
-      if !channel.save(hash)
+      if !channel.save
         raise Discourse::InvalidParameters, 'Channel is not valid'
       end
 
@@ -121,7 +121,7 @@ class DiscourseChat::ChatController < ApplicationController
       hash = params.require(:rule).permit(:channel_id, :type, :filter, :group_id, :category_id, tags: [])
       rule = DiscourseChat::Rule.new(hash)
 
-      if !rule.save(hash)
+      if !rule.save
         raise Discourse::InvalidParameters, 'Rule is not valid'
       end
 


### PR DESCRIPTION
I think that passing attributes to save method is not necessary when the Object was initialized with them.

Problem is that with Rails 6.0.0 (https://github.com/discourse/discourse/pull/8083) this code is not working https://travis-ci.org/discourse/discourse/jobs/582556988