### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -79,7 +79,7 @@ class DiscourseChat::ChatController < ApplicationController
 
       channel = DiscourseChat::Channel.new(hash)
 
-      if !channel.save(hash)
+      if !channel.save
         raise Discourse::InvalidParameters, 'Channel is not valid'
       end
 
@@ -121,7 +121,7 @@ class DiscourseChat::ChatController < ApplicationController
       hash = params.require(:rule).permit(:channel_id, :type, :filter, :group_id, :category_id, tags: [])
       rule = DiscourseChat::Rule.new(hash)
 
-      if !rule.save(hash)
+      if !rule.save
         raise Discourse::InvalidParameters, 'Rule is not valid'
       end
 

--- a/app/jobs/onceoff/add_type_field.rb
+++ b/app/jobs/onceoff/add_type_field.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class DiscourseChatAddTypeField < Jobs::Onceoff
+  class DiscourseChatAddTypeField < ::Jobs::Onceoff
     def execute_onceoff(args)
       DiscourseChat::Rule.find_each do |rule|
         rule.save(validate: false)

--- a/app/jobs/onceoff/migrate_from_slack_official.rb
+++ b/app/jobs/onceoff/migrate_from_slack_official.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class DiscourseChatMigrateFromSlackOfficial < Jobs::Onceoff
+  class DiscourseChatMigrateFromSlackOfficial < ::Jobs::Onceoff
     def execute_onceoff(args)
       slack_installed = PluginStoreRow.where(plugin_name: 'discourse-slack-official').exists?
 

--- a/app/jobs/regular/notify_chats.rb
+++ b/app/jobs/regular/notify_chats.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class NotifyChats < Jobs::Base
+  class NotifyChats < ::Jobs::Base
     sidekiq_options retry: false
 
     def execute(args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364