### PR TITLE
FIX: telegram: Not all channel posts contain text

### DIFF
--- a/lib/discourse_chat/provider/telegram/telegram_command_controller.rb
+++ b/lib/discourse_chat/provider/telegram/telegram_command_controller.rb
@@ -29,7 +29,7 @@ module DiscourseChat::Provider::TelegramProvider
 
         DiscourseChat::Provider::TelegramProvider.sendMessage(message)
 
-      elsif params.key?('channel_post') && params['channel_post']['text'].include?('/getchatid')
+      elsif params.dig('channel_post', 'text')&.include?('/getchatid')
         chat_id = params['channel_post']['chat']['id']
 
         message_text = I18n.t(


### PR DESCRIPTION
The `text` field is marked optional, and is not guaranteed to exist:

https://core.telegram.org/bots/api#message

We should silently ignore these actions (while responding with a
positive acknowledgement) instead of throwing a `NoMethodError`.