### PR TITLE
Enable optional support for threading slack posts

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -34,7 +34,7 @@ class DiscourseChat::ChatController < ApplicationController
 
       post = Topic.find(topic_id.to_i).posts.first
 
-      provider.trigger_notification(post, channel)
+      provider.trigger_notification(post, channel, nil)
 
       render json: success_json
     rescue Discourse::InvalidParameters, ActiveRecord::RecordNotFound => e

--- a/app/helpers/helper.rb
+++ b/app/helpers/helper.rb
@@ -13,7 +13,7 @@ module DiscourseChat
       error_text = I18n.t("chat_integration.provider.#{provider}.parse_error")
 
       case cmd
-      when "watch", "follow", "mute"
+      when "thread", "watch", "follow", "mute"
         return error_text if tokens.empty?
         # If the first token in the command is a tag, this rule applies to all categories
         category_name = tokens[0].start_with?('tag:') ? nil : tokens.shift

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -31,15 +31,16 @@ class DiscourseChat::Rule < DiscourseChat::PluginModel
     "
       CASE
       WHEN value::json->>'filter' = 'mute' THEN 1
-      WHEN value::json->>'filter' = 'watch' THEN 2
-      WHEN value::json->>'filter' = 'follow' THEN 3
+      WHEN value::json->>'filter' = 'thread' THEN 2
+      WHEN value::json->>'filter' = 'watch' THEN 3
+      WHEN value::json->>'filter' = 'follow' THEN 4
      END
     ")
   }
 
   after_initialize :init_filter
 
-  validates :filter, inclusion: { in: %w(watch follow mute),
+  validates :filter, inclusion: { in: %w(thread watch follow mute),
                                   message: "%{value} is not a valid filter" }
 
   validates :type, inclusion: { in: %w(normal group_message group_mention),

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -52,7 +52,7 @@ module DiscourseChat
 
       # Sort by order of precedence
       t_prec = { 'group_message' => 0, 'group_mention' => 1, 'normal' => 2 } # Group things win
-      f_prec = { 'mute' => 0, 'watch' => 1, 'follow' => 2 } #(mute always wins; watch beats follow)
+      f_prec = { 'mute' => 0, 'thread' => 1, 'watch' => 2, 'follow' => 3 } #(mute always wins; thread beats watch beats follow)
       sort_func = proc { |a, b| [t_prec[a.type], f_prec[a.filter]] <=> [t_prec[b.type], f_prec[b.filter]] }
       matching_rules = matching_rules.sort(&sort_func)
 
@@ -80,7 +80,7 @@ module DiscourseChat
         next unless is_enabled = ::DiscourseChat::Provider.is_enabled(provider)
 
         begin
-          provider.trigger_notification(post, channel)
+          provider.trigger_notification(post, channel, rule)
           channel.update_attribute('error_key', nil) if channel.error_key
         rescue => e
           if e.class == (DiscourseChat::ProviderError) && e.info.key?(:error_key) && !e.info[:error_key].nil?

--- a/assets/javascripts/admin/models/rule.js.es6
+++ b/assets/javascripts/admin/models/rule.js.es6
@@ -6,23 +6,38 @@ import {
 } from "discourse-common/utils/decorators";
 
 export default RestModel.extend({
-  available_filters: [
-    {
-      id: "watch",
-      name: I18n.t("chat_integration.filter.watch"),
-      icon: "exclamation-circle"
-    },
-    {
-      id: "follow",
-      name: I18n.t("chat_integration.filter.follow"),
-      icon: "circle"
-    },
-    {
-      id: "mute",
-      name: I18n.t("chat_integration.filter.mute"),
-      icon: "times-circle"
+  @computed("channel.provider")
+  available_filters(provider) {
+    const available = [];
+
+    if (provider === "slack") {
+      available.push({
+        id: "thread",
+        name: I18n.t("chat_integration.filter.thread"),
+        icon: "chevron-right"
+      });
     }
-  ],
+
+    available.push(
+      {
+        id: "watch",
+        name: I18n.t("chat_integration.filter.watch"),
+        icon: "exclamation-circle"
+      },
+      {
+        id: "follow",
+        name: I18n.t("chat_integration.filter.follow"),
+        icon: "circle"
+      },
+      {
+        id: "mute",
+        name: I18n.t("chat_integration.filter.mute"),
+        icon: "times-circle"
+      }
+    );
+
+    return available;
+  },
 
   available_types: [
     { id: "normal", name: I18n.t("chat_integration.type.normal") },

--- a/assets/javascripts/admin/routes/admin-plugins-chat-provider.js.es6
+++ b/assets/javascripts/admin/routes/admin-plugins-chat-provider.js.es6
@@ -18,7 +18,7 @@ export default DiscourseRoute.extend({
           "rules",
           channel.rules.map(rule => {
             rule = this.store.createRecord("rule", rule);
-            rule.channel = channel;
+            rule.set("channel", channel);
             return rule;
           })
         );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -36,6 +36,7 @@ en:
         mute: 'Mute'
         follow: 'First post only'
         watch: 'All posts and replies'
+        thread: 'All posts with threaded replies'
       rule_table:
         filter: "Filter"
         category: "Category"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -122,8 +122,9 @@ en:
           tag: "The *%{name}* tag cannot be found."
           category: "The *%{name}* category cannot be found. Available categories: *%{list}*"
         help: |
-          *New rule:* `/discourse [watch|follow|mute] [category] [tag:name]`
+          *New rule:* `/discourse [thread|watch|follow|mute] [category] [tag:name]`
           (you must specify a rule type and at least one category or tag)
+          - *thread* – notify this channel for new topics, thread replies if possible
           - *watch* – notify this channel for new topics and new replies
           - *follow* – notify this channel for new topics
           - *mute* – block notifications to this channel

--- a/lib/discourse_chat/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat/provider/discord/discord_provider.rb
@@ -63,7 +63,7 @@ module DiscourseChat
         message
       end
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         # Adding ?wait=true means that we actually get a success/failure response, rather than returning asynchronously
         webhook_url = "#{channel.data['webhook_url']}?wait=true"
         message = generate_discord_message(post)

--- a/lib/discourse_chat/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat/provider/flowdock/flowdock_provider.rb
@@ -48,7 +48,7 @@ module DiscourseChat::Provider::FlowdockProvider
     message
   end
 
-  def self.trigger_notification(post, channel)
+  def self.trigger_notification(post, channel, rule)
     flow_token = channel.data["flow_token"]
     message = generate_flowdock_message(post, flow_token)
     response = send_message("https://api.flowdock.com/messages", message)

--- a/lib/discourse_chat/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat/provider/gitter/gitter_provider.rb
@@ -10,7 +10,7 @@ module DiscourseChat
         { key: "webhook_url", regex: '^https://webhooks\.gitter\.im/e/\S+$', unique: true, hidden: true }
       ]
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         message = gitter_message(post)
         response = Net::HTTP.post_form(URI(channel.data['webhook_url']), message: message)
         unless response.kind_of? Net::HTTPSuccess

--- a/lib/discourse_chat/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat/provider/groupme/groupme_provider.rb
@@ -71,7 +71,7 @@ module DiscourseChat::Provider::GroupmeProvider
     end
   end
 
-  def self.trigger_notification(post, channel)
+  def self.trigger_notification(post, channel, rule)
     data_package = generate_groupme_message(post)
     self.send_via_webhook(data_package, channel)
   end

--- a/lib/discourse_chat/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat/provider/matrix/matrix_provider.rb
@@ -56,7 +56,7 @@ module DiscourseChat
         message
       end
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         message = generate_matrix_message(post)
 
         response = send_message(channel.data['room_id'], message)

--- a/lib/discourse_chat/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat/provider/mattermost/mattermost_provider.rb
@@ -75,7 +75,7 @@ module DiscourseChat
         message
       end
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         channel_id = channel.data['identifier']
         message = mattermost_message(post, channel_id)
 

--- a/lib/discourse_chat/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat/provider/rocketchat/rocketchat_provider.rb
@@ -68,7 +68,7 @@ module DiscourseChat::Provider::RocketchatProvider
 
   end
 
-  def self.trigger_notification(post, channel)
+  def self.trigger_notification(post, channel, rule)
     channel_id = channel.data['identifier']
     message = rocketchat_message(post, channel_id)
 

--- a/lib/discourse_chat/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat/provider/slack/slack_provider.rb
@@ -79,7 +79,6 @@ module DiscourseChat::Provider::SlackProvider
 
     response = nil
     uri = ""
-    record = DiscourseChat.pstore_get("slack_topic_#{post.topic.id}_#{channel}")
 
     data = {
       token: SiteSetting.chat_integration_slack_access_token,

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -118,6 +118,10 @@ module DiscourseChat::Provider::SlackProvider
         post_content << "[#{username}]: #{url}\n"
       end
 
+      if not @requested_thread_ts.nil?
+        post_content << "<!--SLACK_CHANNEL_ID=#{@channel_id};SLACK_TS=#{@requested_thread_ts}-->"
+      end
+
       post_content
     end
 

--- a/lib/discourse_chat/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat/provider/telegram/telegram_provider.rb
@@ -79,7 +79,7 @@ module DiscourseChat
 
       end
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         chat_id = channel.data['chat_id']
 
         message = {

--- a/lib/discourse_chat/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat/provider/zulip/zulip_provider.rb
@@ -46,7 +46,7 @@ module DiscourseChat
         }
       end
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
 
         stream = channel.data['stream']
         subject = channel.data['subject']

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,7 @@ enabled_site_setting :chat_integration_enabled
 register_asset "stylesheets/chat-integration-admin.scss"
 
 register_svg_icon "rocket" if respond_to?(:register_svg_icon)
+register_svg_icon "fa-arrow-circle-o-right" if respond_to?(:register_svg_icon)
 
 # Site setting validators must be loaded before initialize
 require_relative "lib/discourse_chat/provider/slack/slack_enabled_setting_validator"

--- a/spec/dummy_provider.rb
+++ b/spec/dummy_provider.rb
@@ -10,7 +10,7 @@ RSpec.shared_context "dummy provider" do
       @@sent_messages = []
       @@raise_exception = nil
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         if @@raise_exception
           raise @@raise_exception
         end
@@ -50,7 +50,7 @@ RSpec.shared_context "validated dummy provider" do
 
       @@sent_messages = []
 
-      def self.trigger_notification(post, channel)
+      def self.trigger_notification(post, channel, rule)
         @@sent_messages.push(post: post.id, channel: channel)
       end
 

--- a/spec/helpers/helper_spec.rb
+++ b/spec/helpers/helper_spec.rb
@@ -32,7 +32,12 @@ RSpec.describe DiscourseChat::Manager do
         expect(rule.tags).to eq(nil)
       end
 
-        it 'should work with all three filter types' do
+        it 'should work with all four filter types' do
+          response = DiscourseChat::Helper.process_command(chan1, ['thread', category.slug])
+
+          rule = DiscourseChat::Rule.all.first
+          expect(rule.filter).to eq('thread')
+
           response = DiscourseChat::Helper.process_command(chan1, ['watch', category.slug])
 
           rule = DiscourseChat::Rule.all.first

--- a/spec/lib/discourse_chat/provider/discord/discord_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/discord/discord_provider_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DiscourseChat::Provider::DiscordProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, 'https://discordapp.com/api/webhooks/1234/abcd?wait=true').to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
@@ -22,14 +22,14 @@ RSpec.describe DiscourseChat::Provider::DiscordProvider do
       stub1 = stub_request(:post, 'https://discordapp.com/api/webhooks/1234/abcd?wait=true')
         .with(body: hash_including(embeds: [hash_including(author: hash_including(url: /^https?:\/\//))]))
         .to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, "https://discordapp.com/api/webhooks/1234/abcd?wait=true").to_return(status: 400)
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/lib/discourse_chat/provider/flowdock/flowdock_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/flowdock/flowdock_provider_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe DiscourseChat::Provider::FlowdockProvider do
 
     it 'sends a request' do
       stub1 = stub_request(:post, "https://api.flowdock.com/messages").to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, "https://api.flowdock.com/messages").to_return(status: 404, body: "{ \"error\": \"Not Found\"}")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
   end

--- a/spec/lib/discourse_chat/provider/gitter/gitter_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/gitter/gitter_provider_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe DiscourseChat::Provider::GitterProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, chan1.data['webhook_url']).to_return(body: "OK")
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, chan1.data['webhook_url']).to_return(status: 404, body: "{ \"error\": \"Not Found\"}")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
   end

--- a/spec/lib/discourse_chat/provider/groupme/groupme_provider_spect.rb
+++ b/spec/lib/discourse_chat/provider/groupme/groupme_provider_spect.rb
@@ -15,14 +15,14 @@ RSpec.describe DiscourseChat::Provider::GroupmeProvider do
 
     it 'sends a request' do
       stub1 = stub_request(:post, "https://api.groupme.com/v3/bots/post").to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, "https://api.groupme.com/v3/bots/post").to_return(status: 404, body: "{ \"error\": \"Not Found\"}")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
   end

--- a/spec/lib/discourse_chat/provider/matrix/matrix_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/matrix/matrix_provider_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe DiscourseChat::Provider::MatrixProvider do
 
     it 'sends the message' do
       stub1 = stub_request(:put, %r{https://matrix.org/_matrix/client/r0/rooms/!blah:matrix.org/send/m.room.message/*}).to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:put, %r{https://matrix.org/_matrix/client/r0/rooms/!blah:matrix.org/send/m.room.message/*}).to_return(status: 400, body: '{"errmsg":"M_UNKNOWN"}')
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/lib/discourse_chat/provider/mattermost/mattermost_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/mattermost/mattermost_provider_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DiscourseChat::Provider::MattermostProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, 'https://mattermost.blah/hook/abcd').to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
@@ -40,7 +40,7 @@ RSpec.describe DiscourseChat::Provider::MattermostProvider do
     it 'handles errors correctly' do
       stub1 = stub_request(:post, "https://mattermost.blah/hook/abcd").to_return(status: 500, body: "error")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/lib/discourse_chat/provider/rocketchat/rocketchat_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/rocketchat/rocketchat_provider_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe DiscourseChat::Provider::RocketchatProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, 'https://example.com/abcd').to_return(body: "{\"success\":true}")
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, 'https://example.com/abcd').to_return(status: 400, body: "{}")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/lib/discourse_chat/provider/telegram/telegram_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/telegram/telegram_provider_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe DiscourseChat::Provider::TelegramProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, 'https://api.telegram.org/botTOKEN/sendMessage').to_return(body: "{\"ok\":true}")
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, 'https://api.telegram.org/botTOKEN/sendMessage').to_return(body: "{\"ok\":false, \"description\":\"chat not found\"}")
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/lib/discourse_chat/provider/zulip/zulip_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/zulip/zulip_provider_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe DiscourseChat::Provider::ZulipProvider do
 
     it 'sends a webhook request' do
       stub1 = stub_request(:post, 'https://hello.world/api/v1/messages').to_return(status: 200)
-      described_class.trigger_notification(post, chan1)
+      described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'handles errors correctly' do
       stub1 = stub_request(:post, 'https://hello.world/api/v1/messages').to_return(status: 400, body: '{}')
       expect(stub1).to have_been_requested.times(0)
-      expect { described_class.trigger_notification(post, chan1) }.to raise_exception(::DiscourseChat::ProviderError)
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChat::ProviderError)
       expect(stub1).to have_been_requested.once
     end
 

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -141,11 +141,12 @@ RSpec.describe DiscourseChat::Rule do
     it 'can be sorted by precedence' do
       rule2 = DiscourseChat::Rule.create(channel: channel, filter: 'mute')
       rule3 = DiscourseChat::Rule.create(channel: channel, filter: 'follow')
-      rule4 = DiscourseChat::Rule.create(channel: channel, filter: 'mute')
+      rule4 = DiscourseChat::Rule.create(channel: channel, filter: 'thread')
+      rule5 = DiscourseChat::Rule.create(channel: channel, filter: 'mute')
 
-      expect(DiscourseChat::Rule.all.length).to eq(4)
+      expect(DiscourseChat::Rule.all.length).to eq(5)
 
-      expect(DiscourseChat::Rule.all.order_by_precedence.map(&:filter)).to eq(["mute", "mute", "watch", "follow"])
+      expect(DiscourseChat::Rule.all.order_by_precedence.map(&:filter)).to eq(["mute", "mute", "thread", "watch", "follow"])
     end
   end
 
@@ -190,6 +191,8 @@ RSpec.describe DiscourseChat::Rule do
     end
 
     it 'validates filter correctly' do
+      expect(rule.valid?).to eq(true)
+      rule.filter = 'thread'
       expect(rule.valid?).to eq(true)
       rule.filter = 'follow'
       expect(rule.valid?).to eq(true)

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -93,8 +93,17 @@ RSpec.describe DiscourseChat::Manager do
     end
 
     it "should respect watch over follow" do
-      DiscourseChat::Rule.create!(channel: chan1, filter: 'follow', category_id: nil) # Wildcard watch
+      DiscourseChat::Rule.create!(channel: chan1, filter: 'follow', category_id: nil) # Wildcard follow
       DiscourseChat::Rule.create!(channel: chan1, filter: 'watch', category_id: category.id) # Specific watch
+
+      manager.trigger_notifications(second_post.id)
+
+      expect(provider.sent_to_channel_ids).to contain_exactly(chan1.id)
+    end
+
+    it "should respect thread over watch" do
+      DiscourseChat::Rule.create!(channel: chan1, filter: 'watch', category_id: nil) # Wildcard watch
+      DiscourseChat::Rule.create!(channel: chan1, filter: 'thread', category_id: category.id) # Specific thread
 
       manager.trigger_notifications(second_post.id)
 


### PR DESCRIPTION
In general, this is meant to implement the feature described at https://meta.discourse.org/t/optionally-threading-posts-to-parent-topic-in-slack-integration/150759 but also includes some cleanups. A few lines of unused or redundant code are cleaned up, and the slack API tests are cleaned up to more accurately reflect the slack API. Requesting a thread does not return arbitrary messages outside the thread; the tests have been modified to more accurately represent this. `ts` values are promised to be unique within a channel, so a repetition is changed to follow this contract.