### PR TITLE
FIX: Update telegram webhook correctly and remove old code

### DIFF
--- a/lib/discourse_chat/provider/telegram/telegram_initializer.rb
+++ b/lib/discourse_chat/provider/telegram/telegram_initializer.rb
@@ -1,31 +1,15 @@
 # frozen_string_literal: true
 
-if Gem::Version.new(Discourse::VERSION::STRING) > Gem::Version.new("2.3.0.beta8")
-  DiscourseEvent.on(:site_setting_changed) do |setting_name, old_value, new_value|
-    isEnabledSetting = setting_name == 'chat_integration_telegram_enabled'
-    isAccessToken =  setting_name == 'chat_integration_telegram_access_token'
+DiscourseEvent.on(:site_setting_changed) do |setting_name, old_value, new_value|
+  isEnabledSetting = setting_name == :chat_integration_telegram_enabled
+  isAccessToken =  setting_name == :chat_integration_telegram_access_token
 
-    if (isEnabledSetting || isAccessToken)
-      enabled = isEnabledSetting ? new_value == true : SiteSetting.chat_integration_telegram_enabled
+  if (isEnabledSetting || isAccessToken)
+    enabled = isEnabledSetting ? new_value == true : SiteSetting.chat_integration_telegram_enabled
 
-      if enabled
-        Scheduler::Defer.later("Setup Telegram Webhook") do
-          DiscourseChat::Provider::TelegramProvider.setup_webhook()
-        end
-      end
-    end
-  end
-else
-  DiscourseEvent.on(:site_setting_saved) do |sitesetting|
-    isEnabledSetting = sitesetting.name == 'chat_integration_telegram_enabled'
-    isAccessToken =  sitesetting.name == 'chat_integration_telegram_access_token'
-
-    if (isEnabledSetting || isAccessToken)
-      enabled = isEnabledSetting ? sitesetting.value == 't' : SiteSetting.chat_integration_telegram_enabled
-      if enabled
-        Scheduler::Defer.later("Setup Telegram Webhook") do
-          DiscourseChat::Provider::TelegramProvider.setup_webhook()
-        end
+    if enabled && SiteSetting.chat_integration_telegram_access_token.present?
+      Scheduler::Defer.later("Setup Telegram Webhook") do
+        DiscourseChat::Provider::TelegramProvider.setup_webhook
       end
     end
   end

--- a/spec/lib/discourse_chat/provider/telegram/telegram_command_controller_spec.rb
+++ b/spec/lib/discourse_chat/provider/telegram/telegram_command_controller_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'Telegram Command Controller', type: :request do
   let(:category) { Fabricate(:category) }
   let!(:chan1) { DiscourseChat::Channel.create!(provider: 'telegram', data: { name: 'Amazing Channel', chat_id: '123' }) }
+  let!(:webhook_stub) { stub_request(:post, 'https://api.telegram.org/botTOKEN/setWebhook').to_return(body: "{\"ok\":true}") }
 
   describe 'with plugin disabled' do
     it 'should return a 404' do
@@ -28,9 +29,9 @@ describe 'Telegram Command Controller', type: :request do
   describe 'slash commands endpoint' do
     before do
       SiteSetting.chat_integration_enabled = true
-      SiteSetting.chat_integration_telegram_secret = "shhh"
       SiteSetting.chat_integration_telegram_access_token = "TOKEN"
       SiteSetting.chat_integration_telegram_enabled = true
+      SiteSetting.chat_integration_telegram_secret = "shhh"
     end
 
     let!(:stub) { stub_request(:post, 'https://api.telegram.org/botTOKEN/sendMessage').to_return(body: "{\"ok\":true}") }

--- a/spec/lib/discourse_chat/provider/telegram/telegram_provider_spec.rb
+++ b/spec/lib/discourse_chat/provider/telegram/telegram_provider_spec.rb
@@ -4,12 +4,13 @@ require 'rails_helper'
 
 RSpec.describe DiscourseChat::Provider::TelegramProvider do
   let(:post) { Fabricate(:post) }
+  let!(:webhook_stub) { stub_request(:post, 'https://api.telegram.org/botTOKEN/setWebhook').to_return(body: "{\"ok\":true}") }
 
   describe '.trigger_notifications' do
     before do
       SiteSetting.chat_integration_telegram_access_token = "TOKEN"
-      SiteSetting.chat_integration_telegram_secret = 'shhh'
       SiteSetting.chat_integration_telegram_enabled = true
+      SiteSetting.chat_integration_telegram_secret = 'shhh'
     end
 
     let(:chan1) { DiscourseChat::Channel.create!(provider: 'telegram', data: { name: "Awesome Channel", chat_id: '123' }) }


### PR DESCRIPTION
The `site_setting_changed` event passes the setting name as a symbol, not a string. This commit also removes the backwards-compatible `site_setting_saved` event, which was deprecated in 2.3.0.