### PR TITLE
UX: Style fixes for rule/channel modals

### DIFF
--- a/assets/javascripts/admin/templates/modal/admin-plugins-chat-edit-channel.hbs
+++ b/assets/javascripts/admin/templates/modal/admin-plugins-chat-edit-channel.hbs
@@ -9,7 +9,7 @@
             {{i18n (concat 'chat_integration.provider.' model.channel.provider '.title')}}
           </td>
         </tr>
-        <tr class="instructions">
+        <tr class="chat-instructions">
           <td></td>
           <td></td>
         </tr>
@@ -29,7 +29,7 @@
               {{/if}}
             </td>
           </tr>
-          <tr class="instructions">
+          <tr class="chat-instructions">
             <td></td>
             <td><label>{{i18n (concat 'chat_integration.provider.' model.channel.provider '.param.' param.key '.help')}}</label></td>
           </tr>

--- a/assets/javascripts/admin/templates/modal/admin-plugins-chat-edit-rule.hbs
+++ b/assets/javascripts/admin/templates/modal/admin-plugins-chat-edit-rule.hbs
@@ -9,7 +9,7 @@
             {{i18n (concat 'chat_integration.provider.' model.channel.provider '.title')}}
           </td>
         </tr>
-        <tr class="instructions">
+        <tr class="chat-instructions">
           <td></td>
           <td></td>
         </tr>
@@ -20,7 +20,7 @@
             {{channel-data provider=model.provider channel=model.channel}}
           </td>
         </tr>
-        <tr class="instructions">
+        <tr class="chat-instructions">
           <td></td>
           <td></td>
         </tr>
@@ -31,7 +31,7 @@
             {{combo-box name="type" content=model.rule.available_types value=model.rule.type}}
           </td>
         </tr>
-        <tr class="instructions">
+        <tr class="chat-instructions">
           <td></td>
           <td><label>{{i18n 'chat_integration.edit_rule_modal.instructions.type'}}</label></td>
         </tr>
@@ -42,7 +42,7 @@
             {{combo-box name="filter" content=model.rule.available_filters value=model.rule.filter}}
           </td>
         </tr>
-        <tr class="instructions">
+        <tr class="chat-instructions">
           <td></td>
           <td><label>{{i18n 'chat_integration.edit_rule_modal.instructions.filter'}}</label></td>
         </tr>
@@ -59,7 +59,7 @@
                 overrideWidths=false}}
             </td>
           </tr>
-          <tr class="instructions">
+          <tr class="chat-instructions">
             <td></td>
             <td><label>{{i18n 'chat_integration.edit_rule_modal.instructions.category'}}</label></td>
           </tr>
@@ -70,7 +70,7 @@
               {{combo-box content=model.groups valueAttribute="id" value=model.rule.group_id none="chat_integration.choose_group"}}
             </td>
           </tr>
-          <tr class="instructions">
+          <tr class="chat-instructions">
             <td></td>
             <td><label>{{i18n 'chat_integration.edit_rule_modal.instructions.group'}}</label></td>
           </tr>
@@ -83,7 +83,7 @@
               {{tag-chooser placeholderKey="chat_integration.all_tags" name="tags" tags=model.rule.tags everyTag=true }}
             </td>
           </tr>
-          <tr class="instructions">
+          <tr class="chat-instructions">
             <td></td>
             <td><label>{{i18n 'chat_integration.edit_rule_modal.instructions.tags'}}</label></td>
           </tr>

--- a/assets/stylesheets/chat-integration-admin.scss
+++ b/assets/stylesheets/chat-integration-admin.scss
@@ -55,6 +55,10 @@
   table {
     width: 100%;
 
+    tr {
+      border: none;
+    }
+
     tr.input td {
       padding-top: 10px;
 
@@ -68,7 +72,7 @@
       }
     }
 
-    tr.instructions label {
+    tr.chat-instructions label {
       color: var(--primary-medium, $primary-medium);
     }
   }


### PR DESCRIPTION
These had been broken at some point by core changes:

Before:

<img width="300" alt="Screenshot 2021-01-26 at 19 07 31" src="https://user-images.githubusercontent.com/6270921/105892440-c621ad00-6009-11eb-9a43-f4e222b61708.png"><img width="300" alt="Screenshot 2021-01-26 at 19 07 26" src="https://user-images.githubusercontent.com/6270921/105892435-c4f08000-6009-11eb-9346-99ecac539872.png">

After:

<img width="300" alt="Screenshot 2021-01-26 at 19 05 34" src="https://user-images.githubusercontent.com/6270921/105892469-cf127e80-6009-11eb-944b-1ebeee0baf32.png"><img width="300" alt="Screenshot 2021-01-26 at 19 05 25" src="https://user-images.githubusercontent.com/6270921/105892465-ce79e800-6009-11eb-9637-a636500a9044.png">
