### PR TITLE
FIX: Improve error handling for slack transcript generation

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -167,6 +167,9 @@ en:
           change_first_message: "Change first message..."
           change_last_message: "Change last message..."
           loading: "Loading the transcript..."
+          error_users: "Error: unable to fetch users from Slack"
+          error_history: "Error: unable to fetch channel history from Slack"
+          error_ts: "Error: unable to fetch requested message from Slack"
 
       #######################################
       ########## TELEGRAM STRINGS ###########

--- a/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
+++ b/spec/lib/discourse_chat/provider/slack/slack_command_controller_spec.rb
@@ -307,6 +307,10 @@ describe 'Slack Command Controller', type: :request do
         end
 
         it 'deals with failed API calls correctly' do
+          command_stub = stub_request(:post, "https://slack.com/commands/1234")
+            .with(body: { text: I18n.t("chat_integration.provider.slack.transcript.error_users") })
+            .to_return(body: { ok: true }.to_json)
+
           stub_request(:post, "https://slack.com/api/users.list").to_return(status: 403)
 
           post "/chat-integration/slack/command.json", params: {
@@ -320,6 +324,8 @@ describe 'Slack Command Controller', type: :request do
           json = response.parsed_body
 
           expect(json["text"]).to include(I18n.t("chat_integration.provider.slack.transcript.loading"))
+
+          expect(command_stub).to have_been_requested
         end
 
         it 'errors correctly if there is no api key' do


### PR DESCRIPTION
- Stop using `break` in a block - it doesn't work
- Return specific error messages for user / message-history / message errors
- Tidy up the SlackCommandController to make all non-requestable methods private
- Add a test to ensure error messages are passed correctly to Slack