### PR TITLE
FEATURE: Add support for slack message shortcuts for transcripts

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -157,7 +157,7 @@ en:
 
           *Help:* `/discourse help`
         transcript:
-          modal_title: "Build Transcript"
+          modal_title: "Create Transcript"
           modal_description: "All messages in the thread will be assembled into a single forum post. You will be given the opportunity to edit the transcript before posting."
           transcript_ready: "Transcript ready"
           continue_on_discourse: "Continue on Discourse"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -157,6 +157,10 @@ en:
 
           *Help:* `/discourse help`
         transcript:
+          modal_title: "Build Transcript"
+          modal_description: "All messages in the thread will be assembled into a single forum post. You will be given the opportunity to edit the transcript before posting."
+          transcript_ready: "Transcript ready"
+          continue_on_discourse: "Continue on Discourse"
           error: "Something went wrong when building the transcript, sorry!"
           post_to_discourse: "Click here to draft a post on Discourse with a transcript"
           api_required: "Sorry, this integration isn't setup to support posting transcripts."

--- a/lib/discourse_chat/provider/slack/slack_command_controller.rb
+++ b/lib/discourse_chat/provider/slack/slack_command_controller.rb
@@ -67,8 +67,7 @@ module DiscourseChat::Provider::SlackProvider
 
       Scheduler::Defer.later "Processing slack transcript request" do
         response = build_post_request_response(channel, tokens, slack_channel_id, channel_name, response_url)
-        http = Net::HTTP.new("slack.com", 443)
-        http.use_ssl = true
+        http = DiscourseChat::Provider::SlackProvider.slack_api_http
         req = Net::HTTP::Post.new(URI(response_url), 'Content-Type' => 'application/json')
         req.body = response.to_json
         http.request(req)
@@ -118,8 +117,7 @@ module DiscourseChat::Provider::SlackProvider
 
     def process_interactive(json)
       Scheduler::Defer.later "Processing slack transcript update" do
-        http = Net::HTTP.new("slack.com", 443)
-        http.use_ssl = true
+        http = DiscourseChat::Provider::SlackProvider.slack_api_http
 
         if json[:type] == "block_actions" && json[:actions][0][:action_id] == "null_action"
           # Do nothing

--- a/lib/discourse_chat/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat/provider/slack/slack_provider.rb
@@ -91,8 +91,7 @@ module DiscourseChat::Provider::SlackProvider
   end
 
   def self.send_via_api(post, channel, message)
-    http = Net::HTTP.new("slack.com", 443)
-    http.use_ssl = true
+    http = slack_api_http
 
     response = nil
     uri = ""
@@ -176,6 +175,13 @@ module DiscourseChat::Provider::SlackProvider
       self.send_via_api(post, channel_id, message)
     end
 
+  end
+
+  def self.slack_api_http
+    http = Net::HTTP.new("slack.com", 443)
+    http.use_ssl = true
+    http.read_timeout = 5 # seconds
+    http
   end
 end
 

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -125,6 +125,60 @@ module DiscourseChat::Provider::SlackProvider
       post_content
     end
 
+    def build_modal_ui
+      data = {
+        type: "modal",
+        title: {
+          type: "plain_text",
+          text: I18n.t("chat_integration.provider.slack.transcript.modal_title")
+        },
+        blocks: [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": I18n.t("chat_integration.provider.slack.transcript.modal_description")
+            }
+          }
+        ]
+      }
+
+      if @messages
+        post_content = build_transcript
+        secret = DiscourseChat::Helper.save_transcript(post_content)
+        link = "#{Discourse.base_url}/chat-transcript/#{secret}"
+
+        data[:blocks] << {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": ":writing_hand: *#{I18n.t("chat_integration.provider.slack.transcript.transcript_ready")}*"
+          },
+          "accessory": {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": I18n.t("chat_integration.provider.slack.transcript.continue_on_discourse"),
+              "emoji": true
+            },
+            "style": "primary",
+            "url": link,
+            "action_id": "null_action"
+          }
+        }
+      else
+        data[:blocks] << {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": ":writing_hand: #{I18n.t("chat_integration.provider.slack.transcript.loading")}"
+          }
+        }
+      end
+
+      data
+    end
+
     def build_slack_ui
       post_content = build_transcript
       secret = DiscourseChat::Helper.save_transcript(post_content)

--- a/lib/discourse_chat/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat/provider/slack/slack_transcript.rb
@@ -250,8 +250,7 @@ module DiscourseChat::Provider::SlackProvider
     end
 
     def load_user_data
-      http = Net::HTTP.new("slack.com", 443)
-      http.use_ssl = true
+      http = ::DiscourseChat::Provider::SlackProvider.slack_api_http
 
       cursor = nil
       req = Net::HTTP::Post.new(URI('https://slack.com/api/users.list'))
@@ -280,8 +279,7 @@ module DiscourseChat::Provider::SlackProvider
     end
 
     def load_chat_history(count: 500)
-      http = Net::HTTP.new("slack.com", 443)
-      http.use_ssl = true
+      http = DiscourseChat::Provider::SlackProvider.slack_api_http
 
       endpoint = @requested_thread_ts ? "replies" : "history"
 


### PR DESCRIPTION
Once configured, this adds a new item to the context menu of slack messages. When clicked, the menu item will generate a transcript and present the user with a custom "Post to Discourse" modal. This provides the same functionality as the existing slash-command interface, but is much more user friendly.