### PR TITLE
FIX: Update dashboard warning link to point to new chat-integration URL

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -113,7 +113,7 @@ en:
     group_mention_template: "mentions of: @%{name}"
     group_message_template: "messages to: @%{name}"
 
-    admin_error: "Some chat integration channels have errors. Visit <a href='%{base_path}/admin/plugins/chat'>the chat integration section</a> to find out more."
+    admin_error: "Some chat integration channels have errors. Visit <a href='%{base_path}/admin/plugins/chat-integration'>the chat integration section</a> to find out more."
 
     provider:
 


### PR DESCRIPTION
https://meta.discourse.org/t/chat-integration-error-links-to-the-wrong-url/204977