### PR TITLE
[Matrix] Room aliases and auto-join

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -136,10 +136,11 @@ en:
               help: "A name to describe the channel. It is not used for the connection to Matrix."
             room_id:
               title: "Room ID"
-              help: "The 'private identifier' for the room. It should look something like !abcdefg:matrix.org"
+              help: "The 'private identifier' for the room or its alias. It should look something like !abcdefg:matrix.org or #hijklmn:matrix.org."
           errors:
             unknown_token: "Access token is invalid"
             unknown_room: "Room ID is invalid"
+            forbidden: "Not invited to room"
 
         #######################################
         ############# ZULIP STRINGS ###########

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -50,6 +50,7 @@ en:
     chat_integration_matrix_access_token: "Access token for the bot's Matrix account"
     chat_integration_matrix_excerpt_length: "Matrix post excerpt length"
     chat_integration_matrix_use_notice: "Use notice instead of plain message"
+    chat_integration_matrix_auto_join: "Auto-join rooms even for cacnonical IDs"
 
     #######################################
     ########### ZULIP SETTINGS ############

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,6 +79,8 @@ chat_integration:
     default: 400
   chat_integration_matrix_use_notice:
     default: true
+  chat_integration_matrix_auto_join:
+    default: false
 
 #######################################
 ########### ZULIP SETTINGS ############

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -20,7 +20,7 @@ module DiscourseChatIntegration
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
 
-        if room_id.start_with?("#")
+        if room_id.start_with?("#") || SiteSetting.chat_integration_matrix_auto_join
           url = "#{homeserver}/_matrix/client/r0/join/#{CGI::escape(room_id)}"
           uri = URI([url, url_params].join('?'))
 


### PR DESCRIPTION
I would like to add support for auto-joining rooms to the Matrix provider. It does the auto-join in either of two cases:

* The `auto_join` setting is set globally for the provider
* A room alias is set as room ID

I combined the two because the `join` endpoint in the Matrix Client-Server API conveniently allows passing aliases, and returns the real room ID in the body.

The feature is quite important as we are facing an issue with the limitation that only room IDs are supported, and rooms are not auto-joined: Room Upgrades. When upgrading the room version in Matrix, a new room with a new ID is created. All users have to join the new room, in turn, but all aliases are moved. So allowing both using an alias, and auto-joining, fixes that, without having to re-configure all rooms in Discourse.

The feature comes at the cost of one additional HTTP call.

For adding a test for auto-join, I still have to learn how to write them using Spec.