### PR TITLE
FIX: Remove use of InputValidation library

### DIFF
--- a/assets/javascripts/admin/controllers/modals/admin-plugins-chat-integration-edit-channel.js.es6
+++ b/assets/javascripts/admin/controllers/modals/admin-plugins-chat-integration-edit-channel.js.es6
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import InputValidation from "discourse/models/input-validation";
+import EmberObject from "@ember/object";
 import {
   default as computed,
   observes,
@@ -49,17 +49,17 @@ export default Ember.Controller.extend(ModalFunctionality, {
 
     if (val === "") {
       // Fail silently if field blank
-      return InputValidation.create({
+      return EmberObject.create({
         failed: true,
       });
     } else if (!regString) {
       // Pass silently if no regex available for provider
-      return InputValidation.create({
+      return EmberObject.create({
         ok: true,
       });
     } else if (regex.test(val)) {
       // Test against regex
-      return InputValidation.create({
+      return EmberObject.create({
         ok: true,
         reason: I18n.t(
           "chat_integration.edit_channel_modal.channel_validation.ok"
@@ -67,7 +67,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
       });
     } else {
       // Failed regex
-      return InputValidation.create({
+      return EmberObject.create({
         failed: true,
         reason: I18n.t(
           "chat_integration.edit_channel_modal.channel_validation.fail"


### PR DESCRIPTION
This was deprecated in https://github.com/discourse/discourse/commit/e39d89ecd9119f69f464d92a16d59d77cc746081, and stopped working following the move to Ember CLI