### PR TITLE
FIX: Ensure edit modal validation works on first opening

### DIFF
--- a/assets/javascripts/admin/controllers/modals/admin-plugins-chat-integration-edit-channel.js.es6
+++ b/assets/javascripts/admin/controllers/modals/admin-plugins-chat-integration-edit-channel.js.es6
@@ -31,6 +31,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
           this._paramValidation
         )
       );
+      this.notifyPropertyChange("paramValidation");
     }
   },
 


### PR DESCRIPTION
(Ember's `defineProperty` no longer sees to fire the notifyPropertyChange event, so we need to do it manually)