### PR TITLE
DEV: Update Discord webhook domain

### DIFF
--- a/db/post_migrate/20220215103720_update_discord_webhook_domains.rb
+++ b/db/post_migrate/20220215103720_update_discord_webhook_domains.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class UpdateDiscordWebhookDomains < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      UPDATE plugin_store_rows psr
+      SET value = REPLACE(value, 'discordapp.com', 'discord.com')
+      WHERE psr.plugin_name = 'discourse-chat-integration'
+      AND psr.key LIKE 'channel:%'
+      AND psr.type_name = 'JSON'
+      AND psr.value::json ->> 'provider' = 'discord'
+      AND psr.value::json ->> 'data' LIKE '%https://discordapp.com/%'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -8,11 +8,11 @@ module DiscourseChatIntegration
 
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
-        { key: "webhook_url", regex: '^https:\/\/discord(?:app)?\.com\/api\/webhooks\/', unique: true, hidden: true }
+        { key: "webhook_url", regex: '^https:\/\/discord\.com\/api\/webhooks\/', unique: true, hidden: true }
       ].freeze
 
       def self.send_message(url, message)
-        http = Net::HTTP.new("discordapp.com", 443)
+        http = Net::HTTP.new("discord.com", 443)
         http.use_ssl = true
 
         uri = URI(url)

--- a/spec/lib/discourse_chat_integration/provider/discord/discord_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/discord/discord_provider_spec.rb
@@ -10,16 +10,16 @@ RSpec.describe DiscourseChatIntegration::Provider::DiscordProvider do
       SiteSetting.chat_integration_discord_enabled = true
     end
 
-    let(:chan1) { DiscourseChatIntegration::Channel.create!(provider: 'discord', data: { name: "Awesome Channel", webhook_url: 'https://discordapp.com/api/webhooks/1234/abcd' }) }
+    let(:chan1) { DiscourseChatIntegration::Channel.create!(provider: 'discord', data: { name: "Awesome Channel", webhook_url: 'https://discord.com/api/webhooks/1234/abcd' }) }
 
     it 'sends a webhook request' do
-      stub1 = stub_request(:post, 'https://discordapp.com/api/webhooks/1234/abcd?wait=true').to_return(status: 200)
+      stub1 = stub_request(:post, 'https://discord.com/api/webhooks/1234/abcd?wait=true').to_return(status: 200)
       described_class.trigger_notification(post, chan1, nil)
       expect(stub1).to have_been_requested.once
     end
 
     it 'includes the protocol in the avatar URL' do
-      stub1 = stub_request(:post, 'https://discordapp.com/api/webhooks/1234/abcd?wait=true')
+      stub1 = stub_request(:post, 'https://discord.com/api/webhooks/1234/abcd?wait=true')
         .with(body: hash_including(embeds: [hash_including(author: hash_including(url: /^https?:\/\//))]))
         .to_return(status: 200)
       described_class.trigger_notification(post, chan1, nil)
@@ -27,7 +27,7 @@ RSpec.describe DiscourseChatIntegration::Provider::DiscordProvider do
     end
 
     it 'handles errors correctly' do
-      stub1 = stub_request(:post, "https://discordapp.com/api/webhooks/1234/abcd?wait=true").to_return(status: 400)
+      stub1 = stub_request(:post, "https://discord.com/api/webhooks/1234/abcd?wait=true").to_return(status: 400)
       expect(stub1).to have_been_requested.times(0)
       expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(::DiscourseChatIntegration::ProviderError)
       expect(stub1).to have_been_requested.once


### PR DESCRIPTION
discordapp.com is being deprecated and replaced with discord.com - https://github.com/discord/discord-api-docs/discussions/4510