### PR TITLE
DEV: Adds post_to_slack scriptable for automation

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -236,3 +236,14 @@ en:
             webhook_url:
               title: "Webhook URL"
               help: "The URL provided when you create a new webhook"
+    discourse_automation:
+      scriptables:
+        send_slack_message:
+          title: Send Slack message
+          fields:
+            message:
+              label: Message
+            url:
+              label: URL
+            channel:
+              label: Channel

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -104,6 +104,10 @@ en:
     chat_integration_google_enabled: "Enable the 'Google Chat' chat integration provider"
     chat_integration_google_excerpt_length: "Google Chat post excerpt length"
 
+  discourse_automation:
+    scriptables:
+      send_slack_message:
+        title: Send Slack message
   chat_integration:
 
     all_categories: "(all categories)"

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -106,11 +106,14 @@ module DiscourseChatIntegration::Provider::SlackProvider
       channel: message[:channel].gsub('#', ''),
       attachments: message[:attachments].to_json
     }
-    if message.key?(:thread_ts)
-      data[:thread_ts] = message[:thread_ts]
-    elsif (match = slack_thread_regex.match(post.raw)) && match.captures[0] == channel
-      data[:thread_ts] = match.captures[1]
-      set_slack_thread_ts(post.topic, channel, match.captures[1])
+
+    if post
+      if message.key?(:thread_ts)
+        data[:thread_ts] = message[:thread_ts]
+      elsif (match = slack_thread_regex.match(post.raw)) && match.captures[0] == channel
+        data[:thread_ts] = match.captures[1]
+        set_slack_thread_ts(post.topic, channel, match.captures[1])
+      end
     end
 
     req.set_form_data(data)
@@ -133,7 +136,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
     end
 
     ts = json["ts"]
-    set_slack_thread_ts(post.topic, channel, ts) if !ts.nil?
+    set_slack_thread_ts(post.topic, channel, ts) if !ts.nil? && !post.nil?
 
     response
   end


### PR DESCRIPTION
This allows for the discourse automation plugin to have a "Send Slack
Message" script.

The script fields are a message, url, and slack channel. This will allow
for a custom slack message to be posted but can link back to an
arbitrary url (hopefully a discourse url) like a list of unanswered
topics instead of strictly only allowing a slack message that links back
to a Discourse Post object.