### PR TITLE
FIX: Use correct copy for 'all categories'

### DIFF
--- a/assets/javascripts/admin/templates/modal/admin-plugins-chat-integration-edit-rule.hbs
+++ b/assets/javascripts/admin/templates/modal/admin-plugins-chat-integration-edit-rule.hbs
@@ -57,10 +57,8 @@
               <td>
                 {{category-chooser
                   name="category"
+                  none="chat_integration.all_categories"
                   value=model.rule.category_id
-                  rootNoneLabel="chat_integration.all_categories"
-                  rootNone=true
-                  overrideWidths=false
                 }}
               </td>
             </tr>


### PR DESCRIPTION
The select-kit API has changed since this plugin's original implementation. `rootNoneLabel` and `rootNone` have been replaced with `none`