### PR TITLE
FIX: Use correct identifier in transcript thread hint

### DIFF
--- a/lib/discourse_chat_integration/provider/slack/slack_transcript.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_transcript.rb
@@ -121,7 +121,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
       end
 
       if not @requested_thread_ts.nil?
-        post_content << "<!--SLACK_CHANNEL_ID=#{@channel_id};SLACK_TS=#{@requested_thread_ts}-->"
+        post_content << "<!--SLACK_CHANNEL_ID=#{@channel_name};SLACK_TS=#{@requested_thread_ts}-->"
       end
 
       post_content

--- a/spec/lib/discourse_chat_integration/provider/slack/slack_transcript_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/slack/slack_transcript_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider::SlackTranscrip
 
       it 'includes slack thread identifiers in body' do
         text = thread_transcript.build_transcript
-        expect(text).to include("<!--SLACK_CHANNEL_ID=G1234;SLACK_TS=1501801629.052212-->")
+        expect(text).to include("<!--SLACK_CHANNEL_ID=#general;SLACK_TS=1501801629.052212-->")
       end
 
     end


### PR DESCRIPTION
We were using the internal UID of the channel in the hint, which would then fail to match any 'channel' configs in Discourse (which use the human-friendly `#channel` format). This was causing automatic threading for transcripts to fail.