### PR TITLE
FIX: Correct error in AdminDashboardData problem check

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -29,7 +29,7 @@ after_initialize do
   add_admin_route 'chat_integration.menu_title', 'chat-integration'
 
   AdminDashboardData.add_problem_check do
-    break if !SiteSetting.chat_integration_enabled
+    next if !SiteSetting.chat_integration_enabled
 
     error = false
     DiscourseChatIntegration::Channel.find_each do |channel|


### PR DESCRIPTION
This would cause admin checks to fail when the plugin is disabled.

Unfortunately plugin-contributed AdminDashboardData checks are not currently testable, but I hope to fix that in a future core commit.

Follow-up to 8de3e498b2814ffd87220b4de8051577abf8c5de