### PR TITLE
UX: admin controls alignment

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-chat-integration.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-chat-integration.hbs
@@ -12,12 +12,12 @@
       </ul>
     </div>
 
-      {{d-button
-        action=(route-action "showSettings")
-        icon="cog"
-        title="chat_integration.settings"
-        label="chat_integration.settings"
-      }}
+    {{d-button
+      action=(route-action "showSettings")
+      icon="cog"
+      title="chat_integration.settings"
+      label="chat_integration.settings"
+    }}
   </div>
 
   {{#unless model.totalRows}}

--- a/assets/javascripts/discourse/templates/admin/plugins-chat-integration.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-chat-integration.hbs
@@ -1,6 +1,6 @@
 <div id="admin-plugin-chat">
   <div class="admin-controls">
-    <div class="span15">
+    <div class="admin-controls-chat-providers">
       <ul class="nav nav-pills">
         {{#each model as |provider|}}
           {{nav-item
@@ -12,14 +12,12 @@
       </ul>
     </div>
 
-    <div class="pull-right">
       {{d-button
         action=(route-action "showSettings")
         icon="cog"
         title="chat_integration.settings"
         label="chat_integration.settings"
       }}
-    </div>
   </div>
 
   {{#unless model.totalRows}}

--- a/assets/stylesheets/chat-integration-admin.scss
+++ b/assets/stylesheets/chat-integration-admin.scss
@@ -47,6 +47,17 @@
       overflow: auto;
     }
   }
+
+  .admin-controls {
+    padding: 10px;
+    .nav-pills {
+      padding: 0;
+    }
+  }
+}
+
+.admin-controls-chat-providers {
+  margin-right: auto;
 }
 
 #chat-integration-edit-channel-modal,


### PR DESCRIPTION
We usually push the settings button to the right, the old float here isn't working

Before: 
<img width="909" alt="Screen Shot 2022-04-15 at 10 37 16 AM" src="https://user-images.githubusercontent.com/1681963/163583939-1e97c0ef-4e15-4778-983a-2e7669aa2b86.png">

After:
<img width="928" alt="Screen Shot 2022-04-15 at 10 35 53 AM" src="https://user-images.githubusercontent.com/1681963/163583950-a6b67a92-3487-430a-a743-7c6302e024e1.png">

