### PR TITLE
FIX: Respect core settings when rendering user names/usernames

### DIFF
--- a/app/helpers/helper.rb
+++ b/app/helpers/helper.rb
@@ -202,8 +202,8 @@ module DiscourseChatIntegration
       end
 
       full_name = user.name
-
-      similar = (full_name.strip.gsub(' ', '_').casecmp(user.username) == 0) || (full_name.strip.gsub(' ', '').casecmp(user.username) == 0)
+      full_name_normalized = User.normalize_username(full_name.strip)
+      similar = full_name_normalized.gsub(' ', '_') == user.username_lower  || full_name_normalized.gsub(' ', '') == user.username_lower
       if similar && SiteSetting.prioritize_username_in_ux?
         "@#{user.username}"
       elsif similar

--- a/app/helpers/helper.rb
+++ b/app/helpers/helper.rb
@@ -203,7 +203,7 @@ module DiscourseChatIntegration
 
       full_name = user.name
       full_name_normalized = User.normalize_username(full_name.strip)
-      similar = full_name_normalized.gsub(' ', '_') == user.username_lower  || full_name_normalized.gsub(' ', '') == user.username_lower
+      similar = full_name_normalized.gsub(' ', '_') == user.username_lower || full_name_normalized.gsub(' ', '') == user.username_lower
       if similar && SiteSetting.prioritize_username_in_ux?
         "@#{user.username}"
       elsif similar

--- a/app/helpers/helper.rb
+++ b/app/helpers/helper.rb
@@ -196,5 +196,23 @@ module DiscourseChatIntegration
       secret
     end
 
+    def self.formatted_display_name(user)
+      if !SiteSetting.enable_names || user.name.blank?
+        return "@#{user.username}"
+      end
+
+      full_name = user.name
+
+      similar = (full_name.strip.gsub(' ', '_').casecmp(user.username) == 0) || (full_name.strip.gsub(' ', '').casecmp(user.username) == 0)
+      if similar && SiteSetting.prioritize_username_in_ux?
+        "@#{user.username}"
+      elsif similar
+        full_name
+      elsif SiteSetting.prioritize_username_in_ux?
+        "@#{user.username} (#{full_name})"
+      else
+        "#{full_name} (@#{user.username})"
+      end
+    end
   end
 end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -30,13 +30,7 @@ module DiscourseChatIntegration
       end
 
       def self.generate_discord_message(post)
-
-        display_name = "@#{post.user.username}"
-        full_name = post.user.name || ""
-
-        if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-          display_name = "#{full_name} @#{post.user.username}"
-        end
+        display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -22,12 +22,7 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
   end
 
   def self.generate_flowdock_message(post, flow_token)
-    display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
-
-    if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-      display_name = "#{full_name} @#{post.user.username}"
-    end
+    display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
     message = {
       flow_token: flow_token,

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -7,11 +7,7 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
   ]
 
   def self.generate_groupme_message(post)
-    display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
-    if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-      display_name = "#{full_name} @#{post.user.username}"
-    end
+    display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
     topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -32,13 +32,7 @@ module DiscourseChatIntegration
       end
 
       def self.generate_matrix_message(post)
-
-        display_name = "@#{post.user.username}"
-        full_name = post.user.name || ""
-
-        if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-          display_name = "#{full_name} @#{post.user.username}"
-        end
+        display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         message = {
           msgtype: SiteSetting.chat_integration_matrix_use_notice ? 'm.notice' : 'm.text',

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -31,12 +31,7 @@ module DiscourseChatIntegration
       end
 
       def self.mattermost_message(post, channel)
-        display_name = "@#{post.user.username}"
-        full_name = post.user.name || ""
-
-        if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-          display_name = "#{full_name} @#{post.user.username}"
-        end
+        display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -10,12 +10,7 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
                        ]
 
   def self.rocketchat_message(post, channel)
-    display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
-
-    if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-      display_name = "#{full_name} @#{post.user.username}"
-    end
+    display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
     topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -30,12 +30,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
   end
 
   def self.slack_message(post, channel, filter)
-    display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
-
-    if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-      display_name = "#{full_name} @#{post.user.username}"
-    end
+    display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
     topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -32,7 +32,7 @@ module DiscourseChatIntegration::Provider::TeamsProvider
 
   def self.get_message(post)
     display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
+    full_name = SiteSetting.enable_names ? post.user.name : ""
 
     topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -50,12 +50,7 @@ module DiscourseChatIntegration
       end
 
       def self.message_text(post)
-        display_name = "@#{post.user.username}"
-        full_name = post.user.name || ""
-
-        if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-          display_name = "#{full_name} @#{post.user.username}"
-        end
+        display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         topic = post.topic
 

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -37,8 +37,7 @@ module DiscourseChatIntegration::Provider::WebexProvider
   end
 
   def self.get_message(post)
-    display_name = "@#{post.user.username}"
-    full_name = post.user.name || ""
+    display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
     topic = post.topic
 
@@ -52,7 +51,7 @@ module DiscourseChatIntegration::Provider::WebexProvider
 
     markdown = "**#{topic.title}**: #{category}"
     markdown += " #{topic.tags.map(&:name).join(', ')} " if topic.tags.present?
-    markdown += "(#{post.full_url}) from #{full_name} (#{display_name}):\n"
+    markdown += "(#{post.full_url}) from #{display_name}:\n"
     markdown += post.excerpt(SiteSetting.chat_integration_webex_excerpt_length,
                              text_entities: true,
                              strip_links: true,

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -26,12 +26,7 @@ module DiscourseChatIntegration
       end
 
       def self.generate_zulip_message(post, stream, subject)
-        display_name = "@#{post.user.username}"
-        full_name = post.user.name || ""
-
-        if !(full_name.strip.empty?) && (full_name.strip.gsub(' ', '_').casecmp(post.user.username) != 0) && (full_name.strip.gsub(' ', '').casecmp(post.user.username) != 0)
-          display_name = "#{full_name} @#{post.user.username}"
-        end
+        display_name = ::DiscourseChatIntegration::Helper.formatted_display_name(post.user)
 
         message = I18n.t('chat_integration.provider.zulip.message', user: display_name,
                                                                     post_url: post.full_url,

--- a/spec/helpers/helper_spec.rb
+++ b/spec/helpers/helper_spec.rb
@@ -324,4 +324,32 @@ RSpec.describe DiscourseChatIntegration::Manager do
     end
   end
 
+  describe ".formatted_display_name" do
+    let(:user) { Fabricate.build(:user, name: "John Smith", username: 'js1') }
+
+    it "prioritizes correctly" do
+      SiteSetting.prioritize_username_in_ux = true
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("@#{user.username} (John Smith)")
+      SiteSetting.prioritize_username_in_ux = false
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("John Smith (@#{user.username})")
+    end
+
+    it "only displays one when name/username are similar" do
+      user.username = "john_smith"
+      SiteSetting.prioritize_username_in_ux = true
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("@#{user.username}")
+      SiteSetting.prioritize_username_in_ux = false
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("John Smith")
+    end
+
+    it "only displays username when names are disabled" do
+      SiteSetting.enable_names = false
+
+      SiteSetting.prioritize_username_in_ux = true
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("@#{user.username}")
+      SiteSetting.prioritize_username_in_ux = false
+      expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("@#{user.username}")
+    end
+  end
+
 end

--- a/spec/helpers/helper_spec.rb
+++ b/spec/helpers/helper_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
   end
 
   describe ".formatted_display_name" do
-    let(:user) { Fabricate.build(:user, name: "John Smith", username: 'js1') }
+    let(:user) { Fabricate(:user, name: "John Smith", username: 'js1') }
 
     it "prioritizes correctly" do
       SiteSetting.prioritize_username_in_ux = true
@@ -335,7 +335,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
     end
 
     it "only displays one when name/username are similar" do
-      user.username = "john_smith"
+      user.update!(username: "john_smith")
       SiteSetting.prioritize_username_in_ux = true
       expect(DiscourseChatIntegration::Helper.formatted_display_name(user)).to eq("@#{user.username}")
       SiteSetting.prioritize_username_in_ux = false


### PR DESCRIPTION
This commit centralizes 'display name' generation into a helper, and updates it to respect core preferences for `enable_names` and `prioritize_username_in_ux`.

https://meta.discourse.org/t/discourse-chat-integration-shows-users-name-on-posted-discord-items/181058