### PR TITLE
FIX: Don’t process commands when 'text' is missing

### DIFF
--- a/lib/discourse_chat_integration/provider/telegram/telegram_command_controller.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_command_controller.rb
@@ -58,6 +58,8 @@ module DiscourseChatIntegration::Provider::TelegramProvider
     end
 
     def process_command(message)
+      return unless message['text'] # No command to be processed
+
       chat_id = params['message']['chat']['id']
 
       provider = DiscourseChatIntegration::Provider::TelegramProvider::PROVIDER_NAME

--- a/spec/lib/discourse_chat_integration/provider/telegram/telegram_command_controller_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/telegram/telegram_command_controller_spec.rb
@@ -135,6 +135,18 @@ describe 'Telegram Command Controller', type: :request do
         expect(response.status).to eq(200)
         expect(stub).to have_been_requested.times(1)
       end
+
+      context "when 'text' is missing" do
+        it "does not break" do
+          post '/chat-integration/telegram/command/shhh.json', params: {
+            message: { chat: { id: 123 } }
+          }
+
+          expect(response).to have_http_status :ok
+          expect(DiscourseChatIntegration::Rule.count).to eq(0)
+          expect(DiscourseChatIntegration::Channel.count).to eq(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR concerns the Telegram integration. Currently, we always try to process commands when we receive a hook from Telegram. To do so we rely on the `text` parameters from a Telegram message but the [API documentation](https://core.telegram.org/bots/api#message) tells us this parameters is actually optional. It means sometimes it’s not present in the payload we receive but we still try to access it resulting in a crash.

This PR addresses the issue by simply returning early from the `#process_command` method when `text` is missing from the payload since we don’t have anything to process then.