### PR TITLE
FIX: Always use parent thread_ts for slack threads

### DIFF
--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -144,7 +144,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
                                                           }
     end
 
-    ts = json["ts"]
+    ts = json.dig("message", "thread_ts") || json["ts"]
     set_slack_thread_ts(post.topic, channel, ts) if !ts.nil? && !post.nil?
 
     response

--- a/spec/lib/discourse_chat_integration/provider/slack/slack_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/slack/slack_provider_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider do
         SiteSetting.chat_integration_slack_access_token = "magic"
         @ts = "#{Time.now.to_i}.012345"
         @ts2 = "#{Time.now.to_i}.012346"
+        @ts3 = "#{Time.now.to_i}.0123467"
         @stub1 =
           stub_request(:post, SiteSetting.chat_integration_slack_outbound_webhook_url).to_return(
             body: "success",
@@ -116,17 +117,17 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider do
             body: hash_including("thread_ts" => @ts),
           ).to_return(
             body:
-              "{\"ok\":true, \"ts\": \"#{@ts}\", \"message\": {\"attachments\": [], \"username\":\"blah\", \"text\":\"blah2\"} }",
+              "{\"ok\":true, \"ts\": \"#{@ts}\", \"message\": {\"attachments\": [], \"username\":\"blah\", \"text\":\"blah2\", \"thread_ts\":\"#{@ts}\"} }",
             headers: {
               "Content-Type" => "application/json",
             },
           )
         @thread_stub2 =
           stub_request(:post, %r{https://slack.com/api/chat.postMessage}).with(
-            body: hash_including("thread_ts" => @ts2),
+            body: hash_including("thread_ts" => @ts),
           ).to_return(
             body:
-              "{\"ok\":true, \"ts\": \"#{@ts2}\", \"message\": {\"attachments\": [], \"username\":\"blah\", \"text\":\"blah2\"} }",
+              "{\"ok\":true, \"ts\": \"#{@ts3}\", \"message\": {\"attachments\": [], \"username\":\"blah\", \"text\":\"blah2\", \"thread_ts\":\"#{@ts}\"} }",
             headers: {
               "Content-Type" => "application/json",
             },
@@ -176,7 +177,7 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider do
 
         post.topic.reload
         expect(described_class.get_slack_thread_ts(post.topic, "#general")).to eq(@ts)
-        expect(described_class.get_slack_thread_ts(post.topic, "#random")).to eq(@ts2)
+        expect(described_class.get_slack_thread_ts(post.topic, "#random")).to eq(@ts)
       end
 
       it "recognizes slack thread ts in comment" do


### PR DESCRIPTION
Previously we were using the `ts` of the previous message we sent to the thread. While this did work under some situations, it's not recommended in the Slack API docs, and can lead to some unexpected behavior (e.g. when one of the threaded messages is deleted).

This commit updates our logic to always use Slack's returned `thread_ts`, which represents the thread's parent.