### PR TITLE
FEATURE: New rule filter to send message when topic tags change

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -5,6 +5,7 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
   store :value, accessors: %i[channel_id type group_id category_id tags filter], coder: JSON
 
   scope :with_type, ->(type) { where("value::json->>'type'=?", type.to_s) }
+  scope :with_filter, ->(type) { where("value::json->>'filter'=?", type.to_s) }
   scope :with_channel, ->(channel) { with_channel_id(channel.id) }
   scope :with_channel_id, ->(channel_id) { where("value::json->>'channel_id'=?", channel_id.to_s) }
 
@@ -37,7 +38,8 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
       WHEN value::json->>'filter' = 'mute' THEN 1
       WHEN value::json->>'filter' = 'thread' THEN 2
       WHEN value::json->>'filter' = 'watch' THEN 3
-      WHEN value::json->>'filter' = 'follow' THEN 4
+      WHEN value::json->>'filter' = 'tag_added' THEN 4
+      WHEN value::json->>'filter' = 'follow' THEN 5
      END
     ",
           )
@@ -47,7 +49,7 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
 
   validates :filter,
             inclusion: {
-              in: %w[thread watch follow mute],
+              in: %w[thread watch follow tag_added mute],
               message: "%{value} is not a valid filter",
             }
 

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -5,7 +5,6 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
   store :value, accessors: %i[channel_id type group_id category_id tags filter], coder: JSON
 
   scope :with_type, ->(type) { where("value::json->>'type'=?", type.to_s) }
-  scope :with_filter, ->(type) { where("value::json->>'filter'=?", type.to_s) }
   scope :with_channel, ->(channel) { with_channel_id(channel.id) }
   scope :with_channel_id, ->(channel_id) { where("value::json->>'channel_id'=?", channel_id.to_s) }
 

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -92,7 +92,7 @@ module DiscourseChatIntegration
 
       # Sort by order of precedence
       t_prec = { "group_message" => 0, "group_mention" => 1, "normal" => 2 } # Group things win
-      f_prec = { "mute" => 0, "thread" => 1, "watch" => 2, "follow" => 3 } #(mute always wins; thread beats watch beats follow)
+      f_prec = { "mute" => 0, "thread" => 1, "watch" => 2, "follow" => 3, "tag_added" => 4 } #(mute always wins; thread beats watch beats follow)
       sort_func =
         proc { |a, b| [t_prec[a.type], f_prec[a.filter]] <=> [t_prec[b.type], f_prec[b.filter]] }
       matching_rules = matching_rules.sort(&sort_func)

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -16,7 +16,10 @@ module DiscourseChatIntegration
       return if post.blank?
 
       # Abort if post is not either regular, or a 'tags_changed' small action
-      return if (post.post_type != Post.types[:regular]) && !(post.post_type == Post.types[:small_action] && post.action_code == "tags_changed")
+      if (post.post_type != Post.types[:regular]) &&
+           !(post.post_type == Post.types[:small_action] && post.action_code == "tags_changed")
+        return
+      end
 
       topic = post.topic
       return if topic.blank?
@@ -61,20 +64,20 @@ module DiscourseChatIntegration
 
         unchanged_tags = topic.tags.map(&:name) - tags_added - tags_removed
 
-        matching_rules = matching_rules.select do |rule|
-          # Only rules that match this post, are ones where the filter is "tag_added"
-          next false if rule.filter != "tag_added"
-          next true if rule.tags.blank?
+        matching_rules =
+          matching_rules.select do |rule|
+            # Only rules that match this post, are ones where the filter is "tag_added"
+            next false if rule.filter != "tag_added"
+            next true if rule.tags.blank?
 
-          # Skip if the topic already has one of the tags in the rule, applied
-          next false if unchanged_tags.any? && (unchanged_tags & rule.tags).any?
+            # Skip if the topic already has one of the tags in the rule, applied
+            next false if unchanged_tags.any? && (unchanged_tags & rule.tags).any?
 
-          # We don't need to do any additional filtering here because topics are filtered
-          # by tag later
-          true
-        end
+            # We don't need to do any additional filtering here because topics are filtered
+            # by tag later
+            true
+          end
       end
-
 
       # If tagging is enabled, thow away rules that don't apply to this topic
       if SiteSetting.tagging_enabled

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -29,32 +29,6 @@ module DiscourseChatIntegration
           DiscourseChatIntegration::Rule.with_type("group_message").with_group_ids(
             group_ids_with_access,
           )
-
-        # elsif post.action_code == "tags_changed" && SiteSetting.create_small_action_post_for_tag_changes
-        # Post is a small_action post regarding tags changing for the topic. Check if any tags were _added_
-        # and if so, corresponding rules with `filter: tag_added`
-        # tags_added = post.custom_fields["tags_added"]
-        # tags_added = [tags_added].compact if !tags_added.is_a?(Array)
-        # return if tags_added.blank?
-
-        # tags_removed = post.custom_fields["tags_removed"]
-        # tags_removed = [tags_removed].compact if !tags_removed.is_a?(Array)
-
-        # unchanged_tags = topic.tags.map(&:name) - tags_added - tags_removed
-
-        # tag_rules_matching_category = DiscourseChatIntegration::Rule.with_filter("tag_added").with_category_id(topic.category_id)
-
-        # matching_rules = tag_rules_matching_category.select do |rule|
-          # next true if rule.tags.blank?
-
-          # Skip if the topic already has one of the tags in the rule, applied
-          # next false if unchanged_tags.any? && (unchanged_tags & rule.tags).any?
-
-          # We don't need to do any additional filtering here because topics are filtered
-          # by tag later
-          # true
-        # end
-
       else
         matching_rules =
           DiscourseChatIntegration::Rule.with_type("normal").with_category_id(topic.category_id)

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -12,8 +12,8 @@ module DiscourseChatIntegration
       # Abort if the chat_user doesn't have permission to see the post
       return if !guardian.can_see?(post)
 
-      # Abort if the post is blank, or is non-regular (e.g. a "topic closed" notification)
-      return if post.blank? || post.post_type != Post.types[:regular]
+      # Abort if the post is blank
+      return if post.blank?
 
       topic = post.topic
       return if topic.blank?
@@ -26,7 +26,33 @@ module DiscourseChatIntegration
           DiscourseChatIntegration::Rule.with_type("group_message").with_group_ids(
             group_ids_with_access,
           )
-      else
+
+      elsif post.action_code == "tags_changed" && SiteSetting.create_small_action_post_for_tag_changes
+        # Post is a small_action post regarding tags changing for the topic. Check if any tags were _added_
+        # and if so, corresponding rules with `filter: tag_added`
+        tags_added = post.custom_fields["tags_added"]
+        tags_added = [tags_added].compact if !tags_added.is_a?(Array)
+        return if tags_added.blank?
+
+        tags_removed = post.custom_fields["tags_removed"]
+        tags_removed = [tags_removed].compact if !tags_removed.is_a?(Array)
+
+        unchanged_tags = topic.tags.map(&:name) - tags_added - tags_removed
+
+        tag_rules_matching_category = DiscourseChatIntegration::Rule.with_filter("tag_added").with_category_id(topic.category_id)
+
+        matching_rules = tag_rules_matching_category.select do |rule|
+          next true if rule.tags.blank?
+
+          # Skip if the topic already has one of the tags in the rule, applied
+          next false if unchanged_tags.any? && (unchanged_tags & rule.tags).any?
+
+          # We don't need to do any additional filtering here because topics are filtered
+          # by tag later
+          true
+        end
+
+      elsif post.post_type == Post.types[:regular]
         matching_rules =
           DiscourseChatIntegration::Rule.with_type("normal").with_category_id(topic.category_id)
         if topic.category # Also load the rules for the wildcard category
@@ -44,6 +70,8 @@ module DiscourseChatIntegration
               )
           end
         end
+      else
+        return # No matching rules found - safe to return.
       end
 
       # If tagging is enabled, thow away rules that don't apply to this topic

--- a/assets/javascripts/admin/models/rule.js
+++ b/assets/javascripts/admin/models/rule.js
@@ -47,6 +47,11 @@ export default class Rule extends RestModel {
         icon: "circle",
       },
       {
+        id: "tag_added",
+        name: I18n.t("chat_integration.filter.tag_added"),
+        icon: "tag",
+      },
+      {
         id: "mute",
         name: I18n.t("chat_integration.filter.mute"),
         icon: "times-circle",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -36,6 +36,7 @@ en:
         mute: 'Mute'
         follow: 'First post only'
         watch: 'All posts and replies'
+        tag_added: 'Tag added to topic'
         thread: 'All posts with threaded replies'
       rule_table:
         filter: "Filter"

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
           DiscourseChatIntegration::Rule.create!(
             channel: chan1,
             filter: "tag_added",
-            category_id: category.id
+            category_id: category.id,
           )
 
           manager.trigger_notifications(post.id)
@@ -378,7 +378,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
             channel: chan1,
             filter: "tag_added",
             category_id: category.id,
-            tags: [additional_tag.name]
+            tags: [additional_tag.name],
           )
 
           manager.trigger_notifications(post.id)
@@ -392,7 +392,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
             channel: chan1,
             filter: "tag_added",
             category_id: category.id,
-            tags: [tag.name]
+            tags: [tag.name],
           )
 
           manager.trigger_notifications(post.id)

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe DiscourseChatIntegration::Manager do
         fab!(:admin) { Fabricate(:admin) }
         fab!(:additional_tag) { Fabricate(:tag) }
 
-        before { SiteSetting.create_small_action_post_for_tag_changes = true }
+        before { SiteSetting.create_post_for_category_and_tag_changes = true }
 
         def set_new_tags_and_return_small_action_post(tags)
           PostRevisor.new(tagged_first_post).revise!(admin, tags: tags)

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -398,6 +398,15 @@ RSpec.describe DiscourseChatIntegration::Manager do
           manager.trigger_notifications(post.id)
           expect(provider.sent_to_channel_ids).to contain_exactly
         end
+
+        it "doesn't notify for small action 'tags_changed' posts unless a matching rule exists" do
+          post = set_new_tags_and_return_small_action_post([additional_tag.name])
+
+          DiscourseChatIntegration::Rule.create!(channel: chan1, filter: "watch", category_id: nil) # Wildcard watch
+
+          manager.trigger_notifications(post.id)
+          expect(provider.sent_to_channel_ids).to contain_exactly
+        end
       end
     end
   end


### PR DESCRIPTION
This relies on core PR - 
https://github.com/discourse/discourse/pull/20812

The above PR creates small action posts with tag change information. There are some important custom fields added in there, so that the chat-integration plugin can pick up previous state and new state, then decide if the post is actionable.

The new filter `Tag added` works like a charm with the existing tag filtering setup. If a tag is added to a topic with a matching rule, the rule topic's current tags will be compared with the tags in the rule to decide if the post should make it's way to chat. The post that goes to chat is the small action describing what happened, so there are no additional changes need to explain the chat message.

![Screen Shot 2023-03-24 at 3 29 21 PM](https://user-images.githubusercontent.com/16214023/227639958-c2f05bd9-1409-434d-b6dc-6dc4be3d3367.png)

![Screen Shot 2023-03-24 at 4 05 00 PM](https://user-images.githubusercontent.com/16214023/227640978-1f5a63ab-252e-402f-a96b-98b0de9e300e.png)
