### PR TITLE
FEATURE: Trigger follow rules when category changes

### DIFF
--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -15,7 +15,7 @@ module DiscourseChatIntegration
       # Abort if the post is blank
       return if post.blank?
 
-      # Abort if post is not either regular, or a 'tags_changed' small action
+      # Abort if post is not either regular, or a 'tags_changed'/'category_changed' small action
       if (post.post_type != Post.types[:regular]) &&
            !(
              post.post_type == Post.types[:small_action] &&

--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -17,7 +17,10 @@ module DiscourseChatIntegration
 
       # Abort if post is not either regular, or a 'tags_changed' small action
       if (post.post_type != Post.types[:regular]) &&
-           !(post.post_type == Post.types[:small_action] && post.action_code == "tags_changed")
+           !(
+             post.post_type == Post.types[:small_action] &&
+               %w[tags_changed category_changed].include?(post.action_code)
+           )
         return
       end
 
@@ -104,9 +107,16 @@ module DiscourseChatIntegration
       # If a matching rule is set to mute, we can discard it now
       matching_rules = matching_rules.select { |rule| rule.filter != "mute" }
 
-      # If this is not the first post, discard all "follow" rules
+      # If this is not the first post, discard all "follow" rules. Unless it's a
+      # category_changed action post. If category changed, filter out and rules
+      # that aren't specific to a category
       if !post.is_first_post?
-        matching_rules = matching_rules.select { |rule| rule.filter != "follow" }
+        matching_rules =
+          if post.action_code == "category_changed"
+            matching_rules.select { |rule| rule.category_id.present? }
+          else
+            matching_rules.select { |rule| rule.filter != "follow" }
+          end
       end
 
       # All remaining rules now require a notification to be sent

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -324,7 +324,11 @@ RSpec.describe DiscourseChatIntegration::Manager do
       let(:other_topic_post) { Fabricate(:post, topic: topic) }
 
       it "should trigger follow rules for specific categories when topic category changes" do
-        DiscourseChatIntegration::Rule.create!(channel: chan1, filter: "follow", category_id: category.id)
+        DiscourseChatIntegration::Rule.create!(
+          channel: chan1,
+          filter: "follow",
+          category_id: category.id,
+        )
 
         PostRevisor.new(other_topic_post).revise!(admin, category_id: category.id)
 
@@ -341,7 +345,6 @@ RSpec.describe DiscourseChatIntegration::Manager do
         manager.trigger_notifications(topic.ordered_posts.last.id)
 
         expect(provider.sent_to_channel_ids).to contain_exactly
-
       end
     end
 


### PR DESCRIPTION
This hooks into small action posts created by `PostRevisor`. When a post is created showing that the category for the topic has changed, we look for `follow` rules (on first post) that match _only_ the new category for the topic, and send a message through chat.