### PR TITLE
FIX: stop 'tag_added' rules from firing for normal posts

### DIFF
--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -80,6 +80,8 @@ module DiscourseChatIntegration
             # by tag later
             true
           end
+      else
+        matching_rules = matching_rules.select { |rule| rule.filter != "tag_added" }
       end
 
       # If tagging is enabled, thow away rules that don't apply to this topic

--- a/spec/services/manager_spec.rb
+++ b/spec/services/manager_spec.rb
@@ -417,6 +417,19 @@ RSpec.describe DiscourseChatIntegration::Manager do
           expect(provider.sent_to_channel_ids).to contain_exactly(chan1.id)
         end
 
+        it "doesn't notify when a new regular post is created" do
+          DiscourseChatIntegration::Rule.create!(
+            channel: chan1,
+            filter: "tag_added",
+            category_id: nil,
+            tags: [tag.name],
+          )
+
+          post = Fabricate(:post, topic: tagged_topic)
+          manager.trigger_notifications(post.id)
+          expect(provider.sent_to_channel_ids).to contain_exactly
+        end
+
         it "doesn't notify when topic has an unchanged tag present in the rule, even if a new tag is added" do
           post = set_new_tags_and_return_small_action_post([tag.name, additional_tag.name])
 


### PR DESCRIPTION
There was a bug reported that normal posts in a tagged were sent to chat when a `tag_added` rule was present. This is because we aren't filtering out `tag_added` rules when the post _isn't_ a corresponding small_action post.

This PR filters out those rules!