### PR TITLE
DEV: Replace #pluck_first monkey patch with native #pick

### DIFF
--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -199,7 +199,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
 
   def self.get_slack_thread_ts(topic, channel)
     field = TopicCustomField.where(topic: topic, name: "#{THREAD_CUSTOM_FIELD_PREFIX}#{channel}")
-    field.pluck_first(:value) || topic.custom_fields[THREAD_LEGACY]
+    field.pick(:value) || topic.custom_fields[THREAD_LEGACY]
   end
 
   def self.set_slack_thread_ts(topic, channel, value)


### PR DESCRIPTION
### What is this change?

We have replaced the `#pluck_first` freedom patch with the native `#pick` in core [here](https://github.com/discourse/discourse/pull/19893).

This change is updates this plugin in the same fashion.