### PR TITLE
DEV: Explicitly register problem check

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -19,7 +19,10 @@ require_relative "lib/discourse_chat_integration/provider/slack/slack_enabled_se
 
 after_initialize do
   require_relative "app/initializers/discourse_chat_integration"
+
   require_relative "app/services/problem_check/channel_errors"
+
+  register_problem_check ProblemCheck::ChannelErrors
 
   on(:site_setting_changed) do |setting_name, old_value, new_value|
     is_enabled_setting = setting_name == :chat_integration_telegram_enabled


### PR DESCRIPTION
### What is this change?

In https://github.com/discourse/discourse/pull/26413 we are changing problem checks to require explicit registration. As part of that we're adding a filtered register to the plugin registry. This PR makes use of that new register.