### PR TITLE
Revert "Revert "DEV: Explicitly register problem check""

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -19,7 +19,10 @@ require_relative "lib/discourse_chat_integration/provider/slack/slack_enabled_se
 
 after_initialize do
   require_relative "app/initializers/discourse_chat_integration"
+
   require_relative "app/services/problem_check/channel_errors"
+
+  register_problem_check ProblemCheck::ChannelErrors
 
   on(:site_setting_changed) do |setting_name, old_value, new_value|
     is_enabled_setting = setting_name == :chat_integration_telegram_enabled


### PR DESCRIPTION
Reverts discourse/discourse-chat-integration#192

Reimplement https://github.com/discourse/discourse-chat-integration/pull/191 as the Discourse Core CI issue was unrelated.