### PR TITLE
FIX: Move GroupMe error message to server side translations

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -216,7 +216,6 @@ en:
               help: "name of the Groupme instance as listed in Site Settings. use 'all' to send to all  instances"
           errors:
             not_found: "The path you attempted to post your message to was not found. Check the Bot ID in Site Settings."
-            instance_names_issue: "instance names incorrectly formatted or not provided"
         ############################################
         ######### MICROSOFT TEAMS STRINGS ##########
         ############################################

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -306,3 +306,10 @@ en:
         new_topic: "New topic on %{site_title}"
         author: "by @%{username}"
         link: "View on %{site_title}"
+
+      #######################################
+      ########## GROUPME STRINGS ###########
+      #######################################
+      groupme:
+        errors:
+          instance_names_issue: "instance names incorrectly formatted or not provided"


### PR DESCRIPTION
### What is this change?

The GroupMe provider is looking for a translated error message in the server-side locale file, but the translation has been placed in the client-side file. This fixes that.

**Before:**

```
Randomized with seed 49471
 FF

Failures:

  1) DiscourseChatIntegration::Provider::GroupmeProvider.trigger_notifications sends a request
     Failure/Error: raise I18n::MissingTranslationData.new(locale, key)
     
     I18n::MissingTranslationData:
       Translation missing: en.chat_integration.provider.groupme.errors.instance_names_issue
     # ./lib/freedom_patches/translate_accelerator.rb:150:in `translate_no_override'
     # ./lib/freedom_patches/translate_accelerator.rb:227:in `translate'
     # /Users/drenmi/Workspace/Discourse/discourse-chat-integration/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb:44:in `send_via_webhook'
     # /Users/drenmi/Workspace/Discourse/discourse-chat-integration/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb:85:in `trigger_notification'
     # ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:25:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'

  2) DiscourseChatIntegration::Provider::GroupmeProvider.trigger_notifications handles errors correctly
     Failure/Error:
       expect { described_class.trigger_notification(post, chan1, nil) }.to raise_exception(
         ::DiscourseChatIntegration::ProviderError,
       )
     
       expected DiscourseChatIntegration::ProviderError, got #<I18n::MissingTranslationData: Translation missing: en.chat_integration.provider.groupme.errors.instance_names_issue> with backtrace:
         # ./lib/freedom_patches/translate_accelerator.rb:150:in `translate_no_override'
         # ./lib/freedom_patches/translate_accelerator.rb:227:in `translate'
         # /Users/drenmi/Workspace/Discourse/discourse-chat-integration/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb:44:in `send_via_webhook'
         # /Users/drenmi/Workspace/Discourse/discourse-chat-integration/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb:85:in `trigger_notification'
         # ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:36:in `block (4 levels) in <main>'
         # ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:36:in `block (3 levels) in <main>'
         # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'
     # ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:36:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:460:in `block (2 levels) in <top (required)>'

Finished in 1.58 seconds (files took 2.58 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:23 # DiscourseChatIntegration::Provider::GroupmeProvider.trigger_notifications sends a request
rspec ./plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb:29 # DiscourseChatIntegration::Provider::GroupmeProvider.trigger_notifications handles errors correctly

Randomized with seed 49471
```

**After:**

```
Randomized with seed 61506
..

Finished in 1.54 seconds (files took 2.48 seconds to load)
2 examples, 0 failures

Randomized with seed 61506
```