### PR TITLE
FIX: Move chat integration problem check message to correct locale key

### DIFF
--- a/app/services/problem_check/channel_errors.rb
+++ b/app/services/problem_check/channel_errors.rb
@@ -18,8 +18,4 @@ class ProblemCheck::ChannelErrors < ProblemCheck
         ::DiscourseChatIntegration::Provider.is_enabled(channel.provider)
     end
   end
-
-  def translation_key
-    "chat_integration.admin_error"
-  end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -111,6 +111,10 @@ en:
     chat_integration_google_enabled: "Enable the 'Google Chat' chat integration provider"
     chat_integration_google_excerpt_length: "Google Chat post excerpt length"
 
+  dashboard:
+    problem:
+      channel_errors: "Some chat integration channels have errors. Visit <a href='%{base_path}/admin/plugins/chat-integration'>the chat integration section</a> to find out more."
+
   discourse_automation:
     scriptables:
       send_slack_message:
@@ -123,8 +127,6 @@ en:
 
     group_mention_template: "mentions of: @%{name}"
     group_message_template: "messages to: @%{name}"
-
-    admin_error: "Some chat integration channels have errors. Visit <a href='%{base_path}/admin/plugins/chat-integration'>the chat integration section</a> to find out more."
 
     provider:
 


### PR DESCRIPTION
[Meta](https://meta.discourse.org/t/translation-missing-en-gb-dashboard-problem-channel-errors/311104)

### What is this fix?

As part of enhancing problem checks and admin notices, we standardized the location of the problem check messages' locale keys. However, we overlooked this one in the plugin, resulting in a missing translation on the dashboard.

This PR puts the locale key in the place expected by the admin notice system. (Next there will be a PR in core to make this more robust/easy to catch/configurable.)