### PR TITLE
Feature: add chat integration reference post

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -281,5 +281,11 @@ en:
               label: URL
             channel:
               label: Channel
-            provider:
-              label: Provider
+
+        send_chat_integration_message:
+            title: Send Chat-Integration message
+            fields:
+              channel_name:
+                label: Channel name as shown in the Discourse admin interface
+              provider:
+                label: Provider

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -286,6 +286,7 @@ en:
             title: Send Chat-Integration message
             fields:
               channel_name:
-                label: Channel name as shown in the Discourse admin interface
+                label: Channel name
+                description: "You can find the channel name in the Chat Integration settings"
               provider:
                 label: Provider

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -281,3 +281,5 @@ en:
               label: URL
             channel:
               label: Channel
+            provider:
+              label: Provider

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -283,10 +283,10 @@ en:
               label: Channel
 
         send_chat_integration_message:
-            title: Send Chat-Integration message
-            fields:
-              channel_name:
-                label: Channel name
-                description: "You can find the channel name in the Chat Integration settings"
-              provider:
-                label: Provider
+          title: Send Chat-Integration message
+          fields:
+            channel_name:
+              label: Channel name
+              description: "You can find the channel name in the Chat Integration settings"
+            provider:
+              label: Provider

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -125,6 +125,8 @@ en:
     scriptables:
       send_slack_message:
         title: Send Slack message
+      send_chat_integration_message:
+        title: Send Chat-Integration message
   chat_integration:
 
     all_categories: "(all categories)"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -136,6 +136,12 @@ en:
     group_mention_template: "mentions of: @%{name}"
     group_message_template: "messages to: @%{name}"
 
+
+    topic_tag_changed:
+      added_and_removed: "Added %{added} and removed %{removed}"
+      added: "Added %{added}"
+      removed: "Removed %{removed}"
+      
     provider:
 
       #######################################

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -141,7 +141,7 @@ en:
       added_and_removed: "Added %{added} and removed %{removed}"
       added: "Added %{added}"
       removed: "Removed %{removed}"
-      
+
     provider:
 
       #######################################

--- a/db/migrate/20240808175526_migrate_tag_added_from_filter_to_automation.rb
+++ b/db/migrate/20240808175526_migrate_tag_added_from_filter_to_automation.rb
@@ -1,92 +1,96 @@
 # frozen_string_literal: true
-class MigrateTagAddedFromFilterToAutomation < ActiveRecord::Migration[7.1]
-  def up
-    if defined?(DiscourseAutomation) &&
-         DiscourseChatIntegration::Channel.with_provider("slack").exists?
-      begin
-        DiscourseChatIntegration::Rule
-          .where("value::json->>'filter'=?", "tag_added")
-          .each do |rule|
-            channel_id = rule.value["channel_id"]
-            channel_name =
-              DiscourseChatIntegration::Channel.find(channel_id).value["data"]["identifier"] # it _must_ have a channel_id
+#
+# The next migration file is a migration that migrates the tag_added filter to an automation.
+# this one uses ActiveRecord which is not recommended for migrations.
+#
+# class MigrateTagAddedFromFilterToAutomation < ActiveRecord::Migration[7.1]
+#   def up
+#     if defined?(DiscourseAutomation) &&
+#          DiscourseChatIntegration::Channel.with_provider("slack").exists?
+#       begin
+#         DiscourseChatIntegration::Rule
+#           .where("value::json->>'filter'=?", "tag_added")
+#           .each do |rule|
+#             channel_id = rule.value["channel_id"]
+#             channel_name =
+#               DiscourseChatIntegration::Channel.find(channel_id).value["data"]["identifier"] # it _must_ have a channel_id
 
-            category_id = rule.value["category_id"]
-            tags = rule.value["tags"]
+#             category_id = rule.value["category_id"]
+#             tags = rule.value["tags"]
 
-            automation =
-              DiscourseAutomation::Automation.new(
-                script: "send_slack_message",
-                trigger: "topic_tags_changed",
-                name: "When tags change in topic",
-                enabled: true,
-                last_updated_by_id: Discourse.system_user.id,
-              )
+#             automation =
+#               DiscourseAutomation::Automation.new(
+#                 script: "send_slack_message",
+#                 trigger: "topic_tags_changed",
+#                 name: "When tags change in topic",
+#                 enabled: true,
+#                 last_updated_by_id: Discourse.system_user.id,
+#               )
 
-            automation.save!
+#             automation.save!
 
-            # Triggers:
-            # Watching categories
+#             # Triggers:
+#             # Watching categories
 
-            metadata = (category_id ? { "value" => [category_id] } : {})
+#             metadata = (category_id ? { "value" => [category_id] } : {})
 
-            automation.upsert_field!(
-              "watching_categories",
-              "categories",
-              metadata,
-              target: "trigger",
-            )
+#             automation.upsert_field!(
+#               "watching_categories",
+#               "categories",
+#               metadata,
+#               target: "trigger",
+#             )
 
-            # Watching tags
+#             # Watching tags
 
-            metadata = (tags ? { "value" => tags } : {})
+#             metadata = (tags ? { "value" => tags } : {})
 
-            automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
+#             automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
 
-            # Script options:
-            # Message
-            automation.upsert_field!(
-              "message",
-              "message",
-              { "value" => "${ADDED_AND_REMOVED}" },
-              target: "script",
-            )
+#             # Script options:
+#             # Message
+#             automation.upsert_field!(
+#               "message",
+#               "message",
+#               { "value" => "${ADDED_AND_REMOVED}" },
+#               target: "script",
+#             )
 
-            # URL
-            automation.upsert_field!(
-              "url",
-              "text",
-              { "value" => Discourse.current_hostname },
-              target: "script",
-            )
+#             # URL
+#             automation.upsert_field!(
+#               "url",
+#               "text",
+#               { "value" => Discourse.current_hostname },
+#               target: "script",
+#             )
 
-            # Channel
-            automation.upsert_field!(
-              "channel",
-              "text",
-              { "value" => channel_name },
-              target: "script",
-            )
-          end
-      rescue StandardError
-        Rails.logger.warn("Failed to migrate tag_added rules to automations")
-      end
-    end
-  end
+#             # Channel
+#             automation.upsert_field!(
+#               "channel",
+#               "text",
+#               { "value" => channel_name },
+#               target: "script",
+#             )
+#           end
+#       rescue StandardError
+#         Rails.logger.warn("Failed to migrate tag_added rules to automations")
+#       end
+#     end
+#   end
 
-  def down
-    if defined?(DiscourseAutomation) &&
-         DiscourseChatIntegration::Channel.with_provider("slack").exists?
-      DiscourseAutomation::Automation
-        .where(script: "send_slack_message", trigger: "topic_tags_changed")
-        .each do |automation|
-          # if is the same name as created and message is the same
-          if automation.name == "When tags change in topic" &&
-               automation.fields.where(name: "message").first.metadata["value"] ==
-                 "${ADDED_AND_REMOVED}"
-            automation.destroy!
-          end
-        end
-    end
-  end
-end
+#   def down
+#     if defined?(DiscourseAutomation) &&
+#          DiscourseChatIntegration::Channel.with_provider("slack").exists?
+#       DiscourseAutomation::Automation
+#         .where(script: "send_slack_message", trigger: "topic_tags_changed")
+#         .each do |automation|
+#           # if is the same name as created and message is the same
+#           if automation.name == "When tags change in topic" &&
+#                automation.fields.where(name: "message").first.metadata["value"] ==
+#                  "${ADDED_AND_REMOVED}"
+#             automation.destroy!
+#           end
+#         end
+#     end
+#   end
+# end

--- a/db/migrate/20240808175526_migrate_tag_added_from_filter_to_automation.rb
+++ b/db/migrate/20240808175526_migrate_tag_added_from_filter_to_automation.rb
@@ -1,96 +1,96 @@
 # frozen_string_literal: true
-#
+
 # The next migration file is a migration that migrates the tag_added filter to an automation.
 # this one uses ActiveRecord which is not recommended for migrations.
-#
-# class MigrateTagAddedFromFilterToAutomation < ActiveRecord::Migration[7.1]
-#   def up
-#     if defined?(DiscourseAutomation) &&
-#          DiscourseChatIntegration::Channel.with_provider("slack").exists?
-#       begin
-#         DiscourseChatIntegration::Rule
-#           .where("value::json->>'filter'=?", "tag_added")
-#           .each do |rule|
-#             channel_id = rule.value["channel_id"]
-#             channel_name =
-#               DiscourseChatIntegration::Channel.find(channel_id).value["data"]["identifier"] # it _must_ have a channel_id
 
-#             category_id = rule.value["category_id"]
-#             tags = rule.value["tags"]
+class MigrateTagAddedFromFilterToAutomation < ActiveRecord::Migration[7.1]
+  def up
+    # if defined?(DiscourseAutomation) &&
+    #      DiscourseChatIntegration::Channel.with_provider("slack").exists?
+    #   begin
+    #     DiscourseChatIntegration::Rule
+    #       .where("value::json->>'filter'=?", "tag_added")
+    #       .each do |rule|
+    #         channel_id = rule.value["channel_id"]
+    #         channel_name =
+    #           DiscourseChatIntegration::Channel.find(channel_id).value["data"]["identifier"] # it _must_ have a channel_id
 
-#             automation =
-#               DiscourseAutomation::Automation.new(
-#                 script: "send_slack_message",
-#                 trigger: "topic_tags_changed",
-#                 name: "When tags change in topic",
-#                 enabled: true,
-#                 last_updated_by_id: Discourse.system_user.id,
-#               )
+    #         category_id = rule.value["category_id"]
+    #         tags = rule.value["tags"]
 
-#             automation.save!
+    #         automation =
+    #           DiscourseAutomation::Automation.new(
+    #             script: "send_slack_message",
+    #             trigger: "topic_tags_changed",
+    #             name: "When tags change in topic",
+    #             enabled: true,
+    #             last_updated_by_id: Discourse.system_user.id,
+    #           )
 
-#             # Triggers:
-#             # Watching categories
+    #         automation.save!
 
-#             metadata = (category_id ? { "value" => [category_id] } : {})
+    #         # Triggers:
+    #         # Watching categories
 
-#             automation.upsert_field!(
-#               "watching_categories",
-#               "categories",
-#               metadata,
-#               target: "trigger",
-#             )
+    #         metadata = (category_id ? { "value" => [category_id] } : {})
 
-#             # Watching tags
+    #         automation.upsert_field!(
+    #           "watching_categories",
+    #           "categories",
+    #           metadata,
+    #           target: "trigger",
+    #         )
 
-#             metadata = (tags ? { "value" => tags } : {})
+    #         # Watching tags
 
-#             automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
+    #         metadata = (tags ? { "value" => tags } : {})
 
-#             # Script options:
-#             # Message
-#             automation.upsert_field!(
-#               "message",
-#               "message",
-#               { "value" => "${ADDED_AND_REMOVED}" },
-#               target: "script",
-#             )
+    #         automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
 
-#             # URL
-#             automation.upsert_field!(
-#               "url",
-#               "text",
-#               { "value" => Discourse.current_hostname },
-#               target: "script",
-#             )
+    #         # Script options:
+    #         # Message
+    #         automation.upsert_field!(
+    #           "message",
+    #           "message",
+    #           { "value" => "${ADDED_AND_REMOVED}" },
+    #           target: "script",
+    #         )
 
-#             # Channel
-#             automation.upsert_field!(
-#               "channel",
-#               "text",
-#               { "value" => channel_name },
-#               target: "script",
-#             )
-#           end
-#       rescue StandardError
-#         Rails.logger.warn("Failed to migrate tag_added rules to automations")
-#       end
-#     end
-#   end
+    #         # URL
+    #         automation.upsert_field!(
+    #           "url",
+    #           "text",
+    #           { "value" => Discourse.current_hostname },
+    #           target: "script",
+    #         )
 
-#   def down
-#     if defined?(DiscourseAutomation) &&
-#          DiscourseChatIntegration::Channel.with_provider("slack").exists?
-#       DiscourseAutomation::Automation
-#         .where(script: "send_slack_message", trigger: "topic_tags_changed")
-#         .each do |automation|
-#           # if is the same name as created and message is the same
-#           if automation.name == "When tags change in topic" &&
-#                automation.fields.where(name: "message").first.metadata["value"] ==
-#                  "${ADDED_AND_REMOVED}"
-#             automation.destroy!
-#           end
-#         end
-#     end
-#   end
-# end
+    #         # Channel
+    #         automation.upsert_field!(
+    #           "channel",
+    #           "text",
+    #           { "value" => channel_name },
+    #           target: "script",
+    #         )
+    #       end
+    #   rescue StandardError
+    #     Rails.logger.warn("Failed to migrate tag_added rules to automations")
+    #   end
+    # end
+  end
+
+  def down
+    # if defined?(DiscourseAutomation) &&
+    #      DiscourseChatIntegration::Channel.with_provider("slack").exists?
+    #   DiscourseAutomation::Automation
+    #     .where(script: "send_slack_message", trigger: "topic_tags_changed")
+    #     .each do |automation|
+    #       # if is the same name as created and message is the same
+    #       if automation.name == "When tags change in topic" &&
+    #            automation.fields.where(name: "message").first.metadata["value"] ==
+    #              "${ADDED_AND_REMOVED}"
+    #         automation.destroy!
+    #       end
+    #     end
+    # end
+  end
+end

--- a/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
+  def up
+    if defined?(DiscourseAutomation)
+      begin
+        DiscourseChatIntegration::Rule
+          .where("value::json->>'filter'=?", "tag_added")
+          .each do |rule|
+            channel_id = rule.channel_id
+            channel = DiscourseChatIntegration::Channel.find(channel_id)
+            # channel names are unique but built from the provider
+            provider_name = channel.provider
+            provider = DiscourseChatIntegration::Provider.get_by_name(provider_name)
+            channel_name = provider.get_channel_name(channel)
+
+            category_id = rule.category_id
+            tags = rule.tags
+
+            automation =
+              DiscourseAutomation::Automation.new(
+                script: "send_chat_integration_message",
+                trigger: "topic_tags_changed",
+                name: "When tags change in topic",
+                enabled: true,
+                last_updated_by_id: Discourse.system_user.id,
+              )
+
+            automation.save!
+
+            # Triggers:
+            # Watching categories
+
+            metadata = (category_id ? { "value" => [category_id] } : {})
+
+            automation.upsert_field!(
+              "watching_categories",
+              "categories",
+              metadata,
+              target: "trigger",
+            )
+
+            # Watching tags
+
+            metadata = (tags ? { "value" => tags } : {})
+            automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
+
+            # Script options:
+            # Provider
+            automation.upsert_field!(
+              "provider",
+              "choices",
+              { "value" => provider_name },
+              target: "script",
+            )
+
+            # Channel name
+            automation.upsert_field!(
+              "channel_name",
+              "text",
+              { "value" => channel_name },
+              target: "script",
+            )
+          end
+      rescue StandardError
+        Rails.logger.warn("Failed to migrate tag_added rule to all providers automations")
+      end
+    end
+  end
+  def down
+    if defined?(DiscourseAutomation)
+      DiscourseAutomation::Automation
+        .where(script: "send_chat_integration_message")
+        .where(trigger: "topic_tags_changed")
+        .where(name: "When tags change in topic")
+        .destroy_all
+    end
+  end
+end

--- a/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -67,7 +67,13 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
               ).with_indifferent_access
 
             provider_name = channel[:provider]
-            provider = DiscourseChatIntegration::Provider.get_by_name(provider_name)
+            provider =
+              DiscourseChatIntegration::Provider
+                .constants
+                .select { |constant| constant.to_s =~ /Provider$/ }
+                .map { |p| DiscourseChatIntegration::Provider.const_get(p) }
+                .find { |p| p::PROVIDER_NAME == provider_name }
+
             channel_name = provider.get_channel_name(channel)
             category_id = rule[:category_id]
             tags = rule[:tags]

--- a/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -56,6 +56,24 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
               VALUES (:automation_id, :name, :component, :metadata, :target, NOW(), NOW())
         SQL
 
+        providers = %i[
+          GroupmeProvider
+          DiscordProvider
+          GuildedProvider
+          MattermostProvider
+          MatrixProvider
+          TeamsProvider
+          ZulipProvider
+          PowerAutomateProvider
+          RocketchatProvider
+          GitterProvider
+          TelegramProvider
+          FlowdockProvider
+          GoogleProvider
+          WebexProvider
+          SlackProvider
+        ]
+
         DB
           .query(rules_with_tag_added)
           .each do |row|
@@ -68,9 +86,7 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
 
             provider_name = channel[:provider]
             provider =
-              DiscourseChatIntegration::Provider
-                .constants
-                .select { |constant| constant.to_s =~ /Provider$/ }
+              providers
                 .map { |p| DiscourseChatIntegration::Provider.const_get(p) }
                 .find { |p| p::PROVIDER_NAME == provider_name }
 

--- a/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -3,76 +3,142 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
   def up
     if defined?(DiscourseAutomation)
       begin
-        # Trash old migration
-        if DiscourseChatIntegration::Channel.with_provider("slack").exists?
-          DiscourseAutomation::Automation
-            .where(script: "send_slack_message", trigger: "topic_tags_changed")
-            .each do |automation|
-              # if is the same name as created and message is the same
-              if automation.name == "When tags change in topic" &&
-                   automation.fields.where(name: "message").first.metadata["value"] ==
-                     "${ADDED_AND_REMOVED}"
-                automation.destroy!
-              end
-            end
-        end
+        slack_count = DB.exec <<~SQL
+        SELECT plugin_store_rows.* FROM plugin_store_rows
+        WHERE plugin_store_rows.type_name = 'JSON'
+        AND plugin_store_rows.plugin_name = 'discourse-chat-integration'
+        AND (key LIKE 'channel:%')
+        AND (value::json->>'provider'='slack')
+        SQL
 
-        DiscourseChatIntegration::Rule
-          .where("value::json->>'filter'=?", "tag_added")
-          .each do |rule|
-            channel_id = rule.channel_id
-            channel = DiscourseChatIntegration::Channel.find(channel_id)
-            # channel names are unique but built from the provider
-            provider_name = channel.provider
+        old_migration_delete = <<~SQL
+        DELETE FROM discourse_automation_automations
+        WHERE id IN (
+          SELECT a.id
+          FROM discourse_automation_automations a
+          JOIN discourse_automation_automation_fields f ON f.automation_id = a.id
+          WHERE a.script = 'send_slack_message'
+            AND a.trigger = 'topic_tags_changed'
+            AND a.name = 'When tags change in topic'
+            AND f.name = 'message'
+            AND f.metadata->>'value' = '${ADDED_AND_REMOVED}'
+        )
+        SQL
+
+        # Trash old migration
+        DB.exec old_migration_delete if slack_count > 0
+
+        rules_with_tag_added = <<~SQL
+        SELECT value
+        FROM plugin_store_rows
+        WHERE plugin_name = 'discourse-chat-integration'
+          AND key LIKE 'rule:%'
+          AND value::json->>'filter' = 'tag_added'
+        SQL
+
+        channel_query = <<~SQL
+        SELECT *
+        FROM plugin_store_rows
+        WHERE type_name = 'JSON'
+          AND plugin_name = 'discourse-chat-integration'
+          AND key LIKE 'channel:%'
+          AND id = :channel_id
+        LIMIT 1
+        SQL
+
+        DB
+          .query(rules_with_tag_added)
+          .each do |row|
+            rule = JSON.parse(row.value).with_indifferent_access
+
+            channel =
+              JSON.parse(
+                DB.query(channel_query, channel_id: rule[:channel_id]).first.value,
+              ).with_indifferent_access
+
+            provider_name = channel[:provider]
             provider = DiscourseChatIntegration::Provider.get_by_name(provider_name)
             channel_name = provider.get_channel_name(channel)
+            category_id = rule[:category_id]
+            tags = rule[:tags]
 
-            category_id = rule.category_id
-            tags = rule.tags
-
-            automation =
-              DiscourseAutomation::Automation.new(
-                script: "send_chat_integration_message",
-                trigger: "topic_tags_changed",
-                name: "When tags change in topic",
-                enabled: true,
-                last_updated_by_id: Discourse.system_user.id,
-              )
-
-            automation.save!
-
-            # Triggers:
-            # Watching categories
-
-            metadata = (category_id ? { "value" => [category_id] } : {})
-
-            automation.upsert_field!(
-              "watching_categories",
-              "categories",
-              metadata,
-              target: "trigger",
+            automation_creation = <<~SQL
+            WITH new_automation AS (
+              INSERT INTO discourse_automation_automations
+              (script, trigger, name, enabled, last_updated_by_id, created_at, updated_at)
+              VALUES
+              ('send_chat_integration_message', 'topic_tags_changed', 'When tags change in topic', true,
+              (SELECT id FROM users WHERE admin = true ORDER BY id ASC LIMIT 1), -- assuming this gets the system user
+              NOW(), NOW())
+              RETURNING id
             )
+            -- Insert watching_categories field
+            INSERT INTO discourse_automation_fields
+            (automation_id, name, type, metadata, target, created_at, updated_at)
+            SELECT
+              new_automation.id,
+              'watching_categories',
+              'categories',
+              CASE
+                WHEN :category_id IS NOT NULL THEN jsonb_build_object('value', jsonb_build_array(:category_id))
+                ELSE '{}'::jsonb
+              END,
+              'trigger',
+              NOW(),
+              NOW()
+            FROM new_automation
+            WHERE :category_id IS NOT NULL;
 
-            # Watching tags
+            -- Insert watching_tags field
+            INSERT INTO discourse_automation_fields
+            (automation_id, name, type, metadata, target, created_at, updated_at)
+            SELECT
+              new_automation.id,
+              'watching_tags',
+              'tags',
+              CASE
+                WHEN :tags IS NOT NULL AND :tags <> '{}' THEN jsonb_build_object('value', :tags::jsonb)
+                ELSE '{}'::jsonb
+              END,
+              'trigger',
+              NOW(),
+              NOW()
+            FROM new_automation
+            WHERE :tags IS NOT NULL AND :tags <> '{}';
 
-            metadata = (tags ? { "value" => tags } : {})
-            automation.upsert_field!("watching_tags", "tags", metadata, target: "trigger")
+            -- Insert provider field
+            INSERT INTO discourse_automation_fields
+            (automation_id, name, type, metadata, target, created_at, updated_at)
+            SELECT
+              new_automation.id,
+              'provider',
+              'choices',
+              jsonb_build_object('value', :provider_name),
+              'script',
+              NOW(),
+              NOW()
+            FROM new_automation;
 
-            # Script options:
-            # Provider
-            automation.upsert_field!(
-              "provider",
-              "choices",
-              { "value" => provider_name },
-              target: "script",
-            )
+            -- Insert channel_name field
+            INSERT INTO discourse_automation_fields
+            (automation_id, name, type, metadata, target, created_at, updated_at)
+            SELECT
+              new_automation.id,
+              'channel_name',
+              'text',
+              jsonb_build_object('value', :channel_name),
+              'script',
+              NOW(),
+              NOW()
+            FROM new_automation;
+            SQL
 
-            # Channel name
-            automation.upsert_field!(
-              "channel_name",
-              "text",
-              { "value" => channel_name },
-              target: "script",
+            DB.exec(
+              automation_creation,
+              category_id: category_id,
+              tags: tags,
+              provider_name: provider_name,
+              channel_name: channel_name,
             )
           end
       rescue StandardError
@@ -82,12 +148,11 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
   end
 
   def down
-    if defined?(DiscourseAutomation)
-      DiscourseAutomation::Automation
-        .where(script: "send_chat_integration_message")
-        .where(trigger: "topic_tags_changed")
-        .where(name: "When tags change in topic")
-        .destroy_all
-    end
+    DB.exec <<~SQL if defined?(DiscourseAutomation)
+        DELETE FROM discourse_automation_automations
+        WHERE script = 'send_chat_integration_message'
+          AND trigger = 'topic_tags_changed'
+          AND name = 'When tags change in topic'
+      SQL
   end
 end

--- a/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
+++ b/db/migrate/20240903184807_migrate_tag_added_filter_to_all_providers.rb
@@ -56,23 +56,23 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
               VALUES (:automation_id, :name, :component, :metadata, :target, NOW(), NOW())
         SQL
 
-        providers = %i[
-          GroupmeProvider
-          DiscordProvider
-          GuildedProvider
-          MattermostProvider
-          MatrixProvider
-          TeamsProvider
-          ZulipProvider
-          PowerAutomateProvider
-          RocketchatProvider
-          GitterProvider
-          TelegramProvider
-          FlowdockProvider
-          GoogleProvider
-          WebexProvider
-          SlackProvider
-        ]
+        provider_identifier_map = {
+          "groupme" => "groupme_instance_name",
+          "discord" => "name",
+          "guilded" => "name",
+          "mattermost" => "identifier",
+          "matrix" => "name",
+          "teams" => "name",
+          "zulip" => "stream",
+          "powerautomate" => "name",
+          "rocketchat" => "identifier",
+          "gitter" => "name",
+          "telegram" => "name",
+          "flowdock" => "flow_token",
+          "google" => "name",
+          "webex" => "name",
+          "slack" => "identifier",
+        }
 
         DB
           .query(rules_with_tag_added)
@@ -85,12 +85,8 @@ class MigrateTagAddedFilterToAllProviders < ActiveRecord::Migration[7.1]
               ).with_indifferent_access
 
             provider_name = channel[:provider]
-            provider =
-              providers
-                .map { |p| DiscourseChatIntegration::Provider.const_get(p) }
-                .find { |p| p::PROVIDER_NAME == provider_name }
+            channel_name = channel[:data][provider_identifier_map[provider_name]]
 
-            channel_name = provider.get_channel_name(channel)
             category_id = rule[:category_id]
             tags = rule[:tags]
 

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -26,8 +26,7 @@ module DiscourseChatIntegration
 
     def excerpt(maxlength = nil, options = {})
       return @excerpt if @excerpt
-      cooked = PostAnalyzer.new(@raw, @topic.id).cook(@raw)
-      @excerpt = Post.excerpt(cooked, maxlength, options.merge(post: self)) # gotta test this well
+      @excerpt = Post.new(raw: raw, topic_id: topic.id, user: user).excerpt(maxlength, options)
       @excerpt
     end
 
@@ -46,7 +45,7 @@ module DiscourseChatIntegration
           lambda { |tag_list| tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ") }
         added_tags = @context["added_tags"]
         removed_tags = @context["removed_tags"]
-        
+
         @raw =
           if added_tags.present? && removed_tags.present?
             I18n.t(

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -2,12 +2,12 @@
 
 module DiscourseChatIntegration
   class ChatIntegrationReferencePost
-    def initialize(context)
+    def initialize(user:, topic:, kind:, raw: nil, context: {})
+      @user = user
+      @topic = topic
+      @kind = kind
+      @raw = raw if raw.present?
       @context = context
-      @user = context["user"]
-      @topic = context["topic"]
-      @kind = context["kind"]
-      @raw = context["raw"] if context["raw"].present?
       @created_at = Time.zone.now
     end
 

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module DiscourseChatIntegration
-  # This _emulates_ a post, but is not a real post
   class ChatIntegrationReferencePost
     def initialize(context)
       @context = context
@@ -21,11 +20,7 @@ module DiscourseChatIntegration
     end
 
     def full_url
-      if @topic.posts.empty?
-        @topic.full_url
-      else
-        @topic.posts.first.full_url
-      end
+      @topic.posts.empty? ? @topic.full_url : @topic.posts.first.full_url
     end
 
     def excerpt(maxlength = nil, options = {})

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -49,14 +49,20 @@ module DiscourseChatIntegration
         @raw =
           if added_tags.present? && removed_tags.present?
             I18n.t(
-              "topic_tag_changed.added_and_removed",
+              "topic_tag_changed.topic_tag_changed.added_and_removed",
               added: tag_list_to_raw.call(added_tags),
               removed: tag_list_to_raw.call(removed_tags),
             )
           elsif added_tags.present?
-            I18n.t("topic_tag_changed.added", added: tag_list_to_raw.call(added_tags))
+            I18n.t(
+              "topic_tag_changed.topic_tag_changed.added",
+              added: tag_list_to_raw.call(added_tags),
+            )
           elsif removed.present?
-            I18n.t("topic_tag_changed.removed", removed: tag_list_to_raw.call(removed_tags))
+            I18n.t(
+              "topic_tag_changed.topic_tag_changed.removed",
+              removed: tag_list_to_raw.call(removed_tags),
+            )
           end
       end
 

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module DiscourseChatIntegration
+  # This _emulates_ a post, but is not a real post
+  class ChatIntegrationReferencePost
+    def initialize(context)
+      @context = context
+      @user = context["user"]
+      @topic = context["topic"]
+      @kind = context["kind"]
+      @full_url = (@topic.posts.empty? ? @topic.full_url : @topic.posts.first.full_url)
+      @created_at = Time.zone.now
+    end
+
+    def user
+      @user
+    end
+
+    def topic
+      @topic
+    end
+
+    def full_url
+      @full_url
+    end
+
+    def excerpt(maxlength = nil, options = {})
+      return @excerpt if @excerpt
+      cooked = PostAnalyzer.new(@raw, @topic.id).cook(@raw)
+      @excerpt = Post.excerpt(cooked, maxlength, options.merge(post: self)) # gotta test this well
+      @excerpt
+    end
+
+    def is_first_post?
+      topic.try(:highest_post_number) == 0
+    end
+
+    def created_at
+      @created_at
+    end
+
+    def raw
+      return @raw if @raw
+      if @kind == DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED
+        tag_list_to_raw =
+          lambda { |tag_list| tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ") }
+        added_tags = @context["added_tags"]
+        removed_tags = @context["removed_tags"]
+        
+        @raw =
+          if added_tags.present? && removed_tags.present?
+            I18n.t(
+              "topic_tag_changed.added_and_removed",
+              added: tag_list_to_raw.call(added_tags),
+              removed: tag_list_to_raw.call(removed_tags),
+            )
+          elsif added_tags.present?
+            I18n.t("topic_tag_changed.added", added: tag_list_to_raw.call(added_tags))
+          elsif removed.present?
+            I18n.t("topic_tag_changed.removed", removed: tag_list_to_raw.call(removed_tags))
+          end
+      end
+    end
+  end
+end

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -8,7 +8,7 @@ module DiscourseChatIntegration
       @kind = kind
       @raw = raw if raw.present?
       @context = context
-      @created_at = Time.zone.now
+      @created_at = Time.current
     end
 
     def id

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -11,6 +11,10 @@ module DiscourseChatIntegration
       @created_at = Time.zone.now
     end
 
+    def id
+      @topic.posts.empty? ? @topic.id : @topic.posts.first.id
+    end
+
     def user
       @user
     end

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -53,18 +53,18 @@ module DiscourseChatIntegration
         @raw =
           if added_tags.present? && removed_tags.present?
             I18n.t(
-              "topic_tag_changed.topic_tag_changed.added_and_removed",
+              "chat_integration.topic_tag_changed.added_and_removed",
               added: tag_list_to_raw.call(added_tags),
               removed: tag_list_to_raw.call(removed_tags),
             )
           elsif added_tags.present?
             I18n.t(
-              "topic_tag_changed.topic_tag_changed.added",
+              "chat_integration.topic_tag_changed.added",
               added: tag_list_to_raw.call(added_tags),
             )
           elsif removed_tags.present?
             I18n.t(
-              "topic_tag_changed.topic_tag_changed.removed",
+              "chat_integration.topic_tag_changed.removed",
               removed: tag_list_to_raw.call(removed_tags),
             )
           end

--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -47,6 +47,7 @@ module DiscourseChatIntegration
         tag_list_to_raw = ->(tag_list) do
           tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ")
         end
+
         added_tags = @context["added_tags"]
         removed_tags = @context["removed_tags"]
 
@@ -69,7 +70,6 @@ module DiscourseChatIntegration
             )
           end
       end
-
       @raw
     end
   end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -94,6 +94,13 @@ module DiscourseChatIntegration
                 )
         end
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -101,6 +101,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -5,7 +5,7 @@ module DiscourseChatIntegration
     module DiscordProvider
       PROVIDER_NAME = "discord".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_discord_enabled
-
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
         {
@@ -98,13 +98,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -104,7 +104,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -101,11 +101,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -70,4 +70,9 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
       )
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["flow_token"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -71,6 +71,6 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -68,9 +68,4 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -60,4 +60,14 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
                                                           }
     end
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value(
+        "flow_token", # this is really weird but is the only way to identify a channel in this provider
+        name,
+      )
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
+++ b/lib/discourse_chat_integration/provider/flowdock/flowdock_provider.rb
@@ -3,6 +3,7 @@
 module DiscourseChatIntegration::Provider::FlowdockProvider
   PROVIDER_NAME = "flowdock".freeze
   PROVIDER_ENABLED_SETTING = :chat_integration_flowdock_enabled
+  CHANNEL_IDENTIFIER_KEY = "flow_token".freeze # this is really weird but is the only way to identify a channel in this provider
   CHANNEL_PARAMETERS = [{ key: "flow_token", regex: '^\S+', unique: true, hidden: true }]
 
   def self.send_message(url, message)
@@ -64,15 +65,12 @@ module DiscourseChatIntegration::Provider::FlowdockProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value(
-        "flow_token", # this is really weird but is the only way to identify a channel in this provider
-        name,
-      )
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["flow_token"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module GitterProvider
       PROVIDER_NAME = "gitter".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_gitter_enabled
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+$', unique: true },
         {
@@ -47,13 +48,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
@@ -50,6 +50,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
@@ -43,6 +43,13 @@ module DiscourseChatIntegration
 
         "[__#{display_name}__ - #{topic.title} - #{category_name}](#{post.full_url})"
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
@@ -54,7 +54,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
+++ b/lib/discourse_chat_integration/provider/gitter/gitter_provider.rb
@@ -51,11 +51,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/google/google_provider.rb
+++ b/lib/discourse_chat_integration/provider/google/google_provider.rb
@@ -118,7 +118,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/google/google_provider.rb
+++ b/lib/discourse_chat_integration/provider/google/google_provider.rb
@@ -115,11 +115,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/google/google_provider.rb
+++ b/lib/discourse_chat_integration/provider/google/google_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module GoogleProvider
       PROVIDER_NAME = "google".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_google_enabled
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+$', unique: true },
         {
@@ -111,13 +112,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/google/google_provider.rb
+++ b/lib/discourse_chat_integration/provider/google/google_provider.rb
@@ -107,6 +107,13 @@ module DiscourseChatIntegration
           ],
         }
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/google/google_provider.rb
+++ b/lib/discourse_chat_integration/provider/google/google_provider.rb
@@ -114,6 +114,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -91,4 +91,9 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
       .with_data_value("groupme_instance_name", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["groupme_instance_name"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -92,9 +92,4 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -95,6 +95,6 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -2,6 +2,7 @@
 module DiscourseChatIntegration::Provider::GroupmeProvider
   PROVIDER_NAME = "groupme".freeze
   PROVIDER_ENABLED_SETTING = :chat_integration_groupme_enabled
+  CHANNEL_IDENTIFIER_KEY = "groupme_instance_name".freeze
   CHANNEL_PARAMETERS = [{ key: "groupme_instance_name", regex: '[\s\S]*', unique: true }]
 
   def self.generate_groupme_message(post)
@@ -88,12 +89,12 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("groupme_instance_name", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["groupme_instance_name"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
+++ b/lib/discourse_chat_integration/provider/groupme/groupme_provider.rb
@@ -84,4 +84,11 @@ module DiscourseChatIntegration::Provider::GroupmeProvider
     data_package = generate_groupme_message(post)
     self.send_via_webhook(data_package, channel)
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("groupme_instance_name", name)
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -102,7 +102,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -5,7 +5,7 @@ module DiscourseChatIntegration
     module GuildedProvider
       PROVIDER_NAME = "guilded".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_guilded_enabled
-
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
         {
@@ -96,13 +96,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -99,11 +99,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -99,6 +99,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -92,6 +92,13 @@ module DiscourseChatIntegration
         return url if !url.start_with?("//")
         "http:#{url}"
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -95,6 +95,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -88,6 +88,13 @@ module DiscourseChatIntegration
           end
         end
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -96,11 +96,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module MatrixProvider
       PROVIDER_NAME = "matrix".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_matrix_enabled
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
         { key: "room_id", regex: '^\!\S+:\S+$', unique: true, hidden: true },
@@ -92,13 +93,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
+++ b/lib/discourse_chat_integration/provider/matrix/matrix_provider.rb
@@ -99,7 +99,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module MattermostProvider
       PROVIDER_NAME = "mattermost".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_mattermost_enabled
+      CHANNEL_IDENTIFIER_KEY = "identifier".freeze
       CHANNEL_PARAMETERS = [{ key: "identifier", regex: '^[@#]\S*$', unique: true }]
 
       def self.send_via_webhook(message)
@@ -97,13 +98,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("identifier", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["identifier"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -93,6 +93,13 @@ module DiscourseChatIntegration
 
         self.send_via_webhook(message)
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("identifier", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -104,7 +104,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -100,6 +100,11 @@ module DiscourseChatIntegration
           .with_data_value("identifier", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["identifier"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -101,11 +101,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -137,4 +137,9 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
       .with_data_value("name", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["name"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -3,6 +3,7 @@
 module DiscourseChatIntegration::Provider::PowerAutomateProvider
   PROVIDER_NAME = "powerautomate"
   PROVIDER_ENABLED_SETTING = :chat_integration_powerautomate_enabled
+  CHANNEL_IDENTIFIER_KEY = "name".freeze
   CHANNEL_PARAMETERS = [
     { key: "name", regex: '^\S+$', unique: true },
     { key: "webhook_url", regex: '^https:\/\/\S+$', unique: true, hidden: true },
@@ -134,12 +135,12 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("name", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["name"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -130,4 +130,11 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
 
     message
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("name", name)
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -141,6 +141,6 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -138,9 +138,4 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -82,4 +82,11 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
 
     self.send_via_webhook(message)
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("identifier", name)
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -89,4 +89,9 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
       .with_data_value("identifier", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["identifier"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -89,9 +89,4 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -4,7 +4,7 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
   PROVIDER_NAME = "rocketchat".freeze
 
   PROVIDER_ENABLED_SETTING = :chat_integration_rocketchat_enabled
-
+  CHANNEL_IDENTIFIER_KEY = "identifier".freeze
   CHANNEL_PARAMETERS = [{ key: "identifier", regex: '^[@#]\S*$', unique: true }]
 
   def self.rocketchat_message(post, channel)
@@ -86,12 +86,12 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("identifier", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["identifier"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -92,6 +92,6 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -349,7 +349,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end
 

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -346,6 +346,11 @@ module DiscourseChatIntegration::Provider::SlackProvider
       .with_data_value("identifier", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["identifier"]
+  end
 end
 
 require_relative "slack_message_formatter"

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -12,7 +12,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
   THREAD_LEGACY = "thread"
 
   PROVIDER_ENABLED_SETTING = :chat_integration_slack_enabled
-
+  CHANNEL_IDENTIFIER_KEY = "identifier".freeze
   CHANNEL_PARAMETERS = [{ key: "identifier", regex: '^[@#]?\S*$', unique: true }]
 
   require_dependency "topic"
@@ -343,13 +343,13 @@ module DiscourseChatIntegration::Provider::SlackProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("identifier", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["identifier"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end
 

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -339,6 +339,13 @@ module DiscourseChatIntegration::Provider::SlackProvider
   def self.create_tag_list(tag_list)
     tag_list.map { |tag_name| "<#{Tag.find_by_name(tag_name).full_url}|#{tag_name}>" }.join(", ")
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("identifier", name)
+      .first
+  end
 end
 
 require_relative "slack_message_formatter"

--- a/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -346,11 +346,6 @@ module DiscourseChatIntegration::Provider::SlackProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end
 
 require_relative "slack_message_formatter"

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -89,4 +89,9 @@ module DiscourseChatIntegration::Provider::TeamsProvider
       .with_data_value("name", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["name"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -90,9 +90,4 @@ module DiscourseChatIntegration::Provider::TeamsProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -93,6 +93,6 @@ module DiscourseChatIntegration::Provider::TeamsProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -3,6 +3,7 @@
 module DiscourseChatIntegration::Provider::TeamsProvider
   PROVIDER_NAME = "teams".freeze
   PROVIDER_ENABLED_SETTING = :chat_integration_teams_enabled
+  CHANNEL_IDENTIFIER_KEY = "name".freeze
   CHANNEL_PARAMETERS = [
     { key: "name", regex: '^\S+$', unique: true },
     { key: "webhook_url", regex: '^https:\/\/\S+$', unique: true, hidden: true },
@@ -86,12 +87,12 @@ module DiscourseChatIntegration::Provider::TeamsProvider
   def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("name", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["name"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -82,4 +82,11 @@ module DiscourseChatIntegration::Provider::TeamsProvider
 
     message
   end
+
+  def self.get_channel_by_name(name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("name", name)
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -117,6 +117,11 @@ module DiscourseChatIntegration
           .with_data_value("name", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["name"]
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -121,7 +121,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module TelegramProvider
       PROVIDER_NAME = "telegram".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_telegram_enabled
+      CHANNEL_IDENTIFIER_KEY = "name".freeze
       CHANNEL_PARAMETERS = [
         { key: "name", regex: '^\S+' },
         { key: "chat_id", regex: '^(-?[0-9]+|@\S+)$', unique: true },
@@ -114,13 +115,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("name", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["name"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -118,11 +118,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -110,6 +110,13 @@ module DiscourseChatIntegration
                                                               }
         end
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("name", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -78,4 +78,9 @@ module DiscourseChatIntegration::Provider::WebexProvider
       .with_data_value("name", name)
       .first
   end
+
+  # used in the MigrateTagAddedFilterToAllProviders migration
+  def self.get_channel_name(channel)
+    channel.data["name"]
+  end
 end

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -3,6 +3,7 @@
 module DiscourseChatIntegration::Provider::WebexProvider
   PROVIDER_NAME = "webex".freeze
   PROVIDER_ENABLED_SETTING = :chat_integration_webex_enabled
+  CHANNEL_IDENTIFIER_KEY = "name".freeze
   CHANNEL_PARAMETERS = [
     { key: "name", regex: '^\S+$', unique: true },
     {
@@ -72,15 +73,15 @@ module DiscourseChatIntegration::Provider::WebexProvider
     { markdown: markdown }
   end
 
-  def self.get_channel_by_name(channel_name)
+  def self.get_channel_by_name(name)
     DiscourseChatIntegration::Channel
       .with_provider(PROVIDER_NAME)
-      .with_data_value("name", name)
+      .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data["name"]
+    channel.data[CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -79,9 +79,4 @@ module DiscourseChatIntegration::Provider::WebexProvider
       .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
       .first
   end
-
-  # used in the MigrateTagAddedFilterToAllProviders migration
-  def self.get_channel_name(channel)
-    channel[:data][CHANNEL_IDENTIFIER_KEY]
-  end
 end

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -71,4 +71,11 @@ module DiscourseChatIntegration::Provider::WebexProvider
 
     { markdown: markdown }
   end
+
+  def self.get_channel_by_name(channel_name)
+    DiscourseChatIntegration::Channel
+      .with_provider(PROVIDER_NAME)
+      .with_data_value("name", name)
+      .first
+  end
 end

--- a/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -82,6 +82,6 @@ module DiscourseChatIntegration::Provider::WebexProvider
 
   # used in the MigrateTagAddedFilterToAllProviders migration
   def self.get_channel_name(channel)
-    channel.data[CHANNEL_IDENTIFIER_KEY]
+    channel[:data][CHANNEL_IDENTIFIER_KEY]
   end
 end

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -71,6 +71,13 @@ module DiscourseChatIntegration
                                                               }
         end
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value("stream", name)
+          .first
+      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -5,6 +5,7 @@ module DiscourseChatIntegration
     module ZulipProvider
       PROVIDER_NAME = "zulip".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_zulip_enabled
+      CHANNEL_IDENTIFIER_KEY = "stream".freeze
       CHANNEL_PARAMETERS = [
         { key: "stream", unique: true, regex: '^\S+' },
         { key: "subject", unique: true, regex: '^\S+' },
@@ -75,13 +76,13 @@ module DiscourseChatIntegration
       def self.get_channel_by_name(name)
         DiscourseChatIntegration::Channel
           .with_provider(PROVIDER_NAME)
-          .with_data_value("stream", name)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data["stream"]
+        channel.data[CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -79,11 +79,6 @@ module DiscourseChatIntegration
           .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
           .first
       end
-
-      # used in the MigrateTagAddedFilterToAllProviders migration
-      def self.get_channel_name(channel)
-        channel[:data][CHANNEL_IDENTIFIER_KEY]
-      end
     end
   end
 end

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -82,7 +82,7 @@ module DiscourseChatIntegration
 
       # used in the MigrateTagAddedFilterToAllProviders migration
       def self.get_channel_name(channel)
-        channel.data[CHANNEL_IDENTIFIER_KEY]
+        channel[:data][CHANNEL_IDENTIFIER_KEY]
       end
     end
   end

--- a/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
+++ b/lib/discourse_chat_integration/provider/zulip/zulip_provider.rb
@@ -78,6 +78,11 @@ module DiscourseChatIntegration
           .with_data_value("stream", name)
           .first
       end
+
+      # used in the MigrateTagAddedFilterToAllProviders migration
+      def self.get_channel_name(channel)
+        channel.data["stream"]
+      end
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -113,6 +113,7 @@ after_initialize do
         begin
           provider.trigger_notification(post, channel, nil)
         rescue StandardError => _
+          Rails.logger.error("Error while sending chat integration message")
         end
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -52,6 +52,15 @@ after_initialize do
 
   if defined?(DiscourseAutomation)
     add_automation_scriptable("send_slack_message") do
+      field :provider,
+            component: :choices,
+            extra: {
+              content:
+                DiscourseChatIntegration::Provider.enabled_provider_names.map do |provider|
+                  { id: provider, name: "chat_integration.provider.#{provider}.title" }
+                end,
+            },
+            required: true
       field :message, component: :message, required: true, accepts_placeholders: true
       field :url, component: :text, required: true
       field :channel, component: :text, required: true
@@ -82,6 +91,17 @@ after_initialize do
         rescue StandardError => _
           # StandardError here is when there are no tags but content includes reference to them.
         end
+
+        # TODO:
+        # provider = fields.dig("provider", "value")
+        # post = DiscourseChatIntegration::ChatIntegrationReferencePost.new(context)
+        # provider = ::DiscourseChatIntegration::Provider.get_by_name(provider)
+
+        # begin
+        #   provider.trigger_notification(post, channel_name, rule = nil) #idk rule part
+        # rescue StandardError => _
+        #   # StandardError here is when there are no tags but content includes reference to them.
+        # end
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,7 @@ register_svg_icon "fa-arrow-circle-o-right" if respond_to?(:register_svg_icon)
 
 # Site setting validators must be loaded before initialize
 require_relative "lib/discourse_chat_integration/provider/slack/slack_enabled_setting_validator"
+require_relative "lib/discourse_chat_integration/chat_integration_reference_post"
 
 after_initialize do
   require_relative "app/initializers/discourse_chat_integration"
@@ -52,15 +53,6 @@ after_initialize do
 
   if defined?(DiscourseAutomation)
     add_automation_scriptable("send_slack_message") do
-      field :provider,
-            component: :choices,
-            extra: {
-              content:
-                DiscourseChatIntegration::Provider.enabled_provider_names.map do |provider|
-                  { id: provider, name: "chat_integration.provider.#{provider}.title" }
-                end,
-            },
-            required: true
       field :message, component: :message, required: true, accepts_placeholders: true
       field :url, component: :text, required: true
       field :channel, component: :text, required: true
@@ -91,17 +83,37 @@ after_initialize do
         rescue StandardError => _
           # StandardError here is when there are no tags but content includes reference to them.
         end
+      end
+    end
 
-        # TODO:
-        # provider = fields.dig("provider", "value")
-        # post = DiscourseChatIntegration::ChatIntegrationReferencePost.new(context)
-        # provider = ::DiscourseChatIntegration::Provider.get_by_name(provider)
+    add_automation_scriptable("send_chat_integration_message") do
+      field :provider,
+            component: :choices,
+            extra: {
+              content:
+                DiscourseChatIntegration::Provider.enabled_provider_names.map do |provider|
+                  { id: provider, name: "chat_integration.provider.#{provider}.title" }
+                end,
+            },
+            required: true
+      field :channel_name, component: :text, required: true
 
-        # begin
-        #   provider.trigger_notification(post, channel_name, rule = nil) #idk rule part
-        # rescue StandardError => _
-        #   # StandardError here is when there are no tags but content includes reference to them.
-        # end
+      version 1
+
+      triggerables %i[topic_tags_changed]
+
+      script do |context, fields, automation|
+        provider = fields.dig("provider", "value")
+        channel_name = fields.dig("channel_name", "value")
+
+        post = DiscourseChatIntegration::ChatIntegrationReferencePost.new(context)
+        provider = DiscourseChatIntegration::Provider.get_by_name(provider)
+
+        channel = provider.get_channel_by_name(channel_name) # user must have created a channel in /admin/plugins/chat-integration/<provider> page
+        begin
+          provider.trigger_notification(post, channel, nil)
+        rescue StandardError => _
+        end
       end
     end
   end

--- a/spec/dummy_provider.rb
+++ b/spec/dummy_provider.rb
@@ -40,6 +40,7 @@ RSpec.shared_context "with validated dummy provider" do
     module ::DiscourseChatIntegration::Provider::Dummy2Provider
       PROVIDER_NAME = "dummy2".freeze
       PROVIDER_ENABLED_SETTING = :chat_integration_enabled # Tie to main plugin enabled setting
+      CHANNEL_IDENTIFIER_KEY = "val".freeze
       CHANNEL_PARAMETERS = [{ key: "val", regex: '^\S+$', unique: true }]
 
       @@sent_messages = []
@@ -51,8 +52,17 @@ RSpec.shared_context "with validated dummy provider" do
       def self.sent_messages
         @@sent_messages
       end
+
+      def self.get_channel_by_name(name)
+        DiscourseChatIntegration::Channel
+          .with_provider(PROVIDER_NAME)
+          .with_data_value(CHANNEL_IDENTIFIER_KEY, name)
+          .first
+      end
     end
   end
 
   after(:each) { ::DiscourseChatIntegration::Provider.send(:remove_const, :Dummy2Provider) }
+
+  let(:validated_provider) { ::DiscourseChatIntegration::Provider::Dummy2Provider }
 end

--- a/spec/integration/automation_spec.rb
+++ b/spec/integration/automation_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Triggering notifications" do
       automation.upsert_field!(
         "provider",
         "choices",
-        { "value" => chan1.provider },
+        { "value" => channel1.provider },
         target: "script",
       )
       automation.upsert_field!("channel_name", "text", { "value" => "chan" }, target: "script")
@@ -56,7 +56,7 @@ RSpec.describe "Triggering notifications" do
 
       expect(validated_provider.sent_messages.length).to eq(1)
       expect(validated_provider.sent_messages.first[:post]).to eq(topic.id)
-      expect(validated_provider.sent_messages.first[:channel]).to eq(chan1)
+      expect(validated_provider.sent_messages.first[:channel]).to eq(channel1)
     end
 
     it "only triggers for the correct tag" do

--- a/spec/integration/automation_spec.rb
+++ b/spec/integration/automation_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require_relative "../dummy_provider"
+RSpec.describe "Triggering notifications" do
+  include_context "with validated dummy provider"
+
+  context "with automation installed", if: defined?(DiscourseAutomation) do
+    fab!(:admin)
+    fab!(:category)
+    fab!(:tag)
+
+    fab!(:automation) do
+      Fabricate(
+        :automation,
+        script: "send_chat_integration_message",
+        trigger: "topic_tags_changed",
+        enabled: true,
+      )
+    end
+    let(:chan1) do
+      DiscourseChatIntegration::Channel.create!(provider: "dummy2", data: { val: "chan" })
+    end
+
+    before do
+      SiteSetting.chat_integration_enabled = true
+      SiteSetting.discourse_automation_enabled = true
+
+      SiteSetting.tagging_enabled = true
+      SiteSetting.create_tag_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      SiteSetting.tag_topic_allowed_groups = Group::AUTO_GROUPS[:everyone]
+
+      automation.upsert_field!(
+        "watching_categories",
+        "categories",
+        { "value" => [category.id] },
+        target: "trigger",
+      )
+      automation.upsert_field!(
+        "watching_tags",
+        "tags",
+        { "value" => [tag.name] },
+        target: "trigger",
+      )
+      automation.upsert_field!(
+        "provider",
+        "choices",
+        { "value" => chan1.provider },
+        target: "script",
+      )
+      automation.upsert_field!("channel_name", "text", { "value" => "chan" }, target: "script")
+    end
+
+    it "triggers a notification" do
+      topic = Fabricate(:topic, user: admin, tags: [], category: category)
+
+      DiscourseTagging.tag_topic_by_names(topic, Guardian.new(admin), [tag.name])
+
+      expect(validated_provider.sent_messages.length).to eq(1)
+      expect(validated_provider.sent_messages.first[:post]).to eq(topic.id)
+      expect(validated_provider.sent_messages.first[:channel]).to eq(chan1)
+    end
+
+    it "only triggers for the correct tag" do
+      topic = Fabricate(:topic, user: admin, tags: [], category: category)
+
+      DiscourseTagging.tag_topic_by_names(topic, Guardian.new(admin), ["other_tag"])
+
+      expect(validated_provider.sent_messages.length).to eq(0)
+    end
+
+    it "only triggers for the correct category" do
+      topic = Fabricate(:topic, user: admin, tags: [], category: Fabricate(:category))
+
+      DiscourseTagging.tag_topic_by_names(topic, Guardian.new(admin), [tag.name])
+
+      expect(validated_provider.sent_messages.length).to eq(0)
+    end
+  end
+end

--- a/spec/integration/automation_spec.rb
+++ b/spec/integration/automation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Triggering notifications" do
         { "value" => channel1.provider },
         target: "script",
       )
-      automation.upsert_field!("channel_name", "text", { "value" => "chan" }, target: "script")
+      automation.upsert_field!("channel_name", "text", { "value" => "channel" }, target: "script")
     end
 
     it "triggers a notification" do

--- a/spec/integration/automation_spec.rb
+++ b/spec/integration/automation_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Triggering notifications" do
         enabled: true,
       )
     end
-    let(:chan1) do
-      DiscourseChatIntegration::Channel.create!(provider: "dummy2", data: { val: "chan" })
+    let(:channel1) do
+      DiscourseChatIntegration::Channel.create!(provider: "dummy2", data: { val: "channel" })
     end
 
     before do

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -20,12 +20,30 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
     end
 
     it "should create a post with the correct raw" do
-      post = described_class.new(context)
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: context["topic"],
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
       expect(post.raw).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
     end
 
     it "should have a working excerpt" do
-      post = described_class.new(context)
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: context["topic"],
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
       expect(post.excerpt).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
     end
   end

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
       expect(post.raw).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
     end
 
-    it "should have a working excerpt" do
+    it "has a working excerpt" do
       post =
         described_class.new(
           user: context["user"],

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
       context["removed_tags"] = %w[tag3 tag4]
     end
 
-    it "should create a post with the correct raw" do
+    it "creates a post with the correct raw" do
       post =
         described_class.new(
           user: context["user"],

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
+  fab!(:topic)
+  fab!(:first_post) { Fabricate(:post, topic: topic) }
+  let!(:context) do
+    {
+      "user" => Fabricate(:user),
+      "topic" => topic,
+      # every rule will add a kind and their context params
+    }
+  end
+
+  describe "when creating when topic tags change" do
+    before do
+      context["kind"] = DiscourseAutomation::Triggers::TOPIC_TAGS_CHANGED
+      context["added_tags"] = %w[tag1 tag2]
+      context["removed_tags"] = %w[tag3 tag4]
+    end
+
+    it "should create a post with the correct raw" do
+      post = described_class.new(context)
+      expect(post.raw).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
+    end
+
+    it "should have a working excerpt" do
+      post = described_class.new(context)
+      expect(post.excerpt).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
+    end
+  end
+end

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "rails_helper"
 
 RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
   fab!(:topic)

--- a/spec/lib/discourse_chat_integration/provider/discord/discord_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/discord/discord_provider_spec.rb
@@ -49,4 +49,18 @@ RSpec.describe DiscourseChatIntegration::Provider::DiscordProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "discord",
+          data: {
+            name: "Awesome Channel",
+            webhook_url: "https://discord.com/api/webhooks/1234/abcd",
+          },
+        )
+      expect(described_class.get_channel_by_name("Awesome Channel")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/flowdock/flowdock_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/flowdock/flowdock_provider_spec.rb
@@ -36,4 +36,19 @@ RSpec.describe DiscourseChatIntegration::Provider::FlowdockProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "flowdock",
+          data: {
+            flow_token: "5d1fe04cf66e078d6a2b579ddb8a465b",
+          },
+        )
+      expect(described_class.get_channel_by_name("5d1fe04cf66e078d6a2b579ddb8a465b")).to eq(
+        expected,
+      )
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/gitter/gitter_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/gitter/gitter_provider_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe DiscourseChatIntegration::Provider::GitterProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "gitter",
+          data: {
+            name: "gitterHQ/services",
+            webhook_url: "https://webhooks.gitter.im/e/a1e2i3o4u5",
+          },
+        )
+      expect(described_class.get_channel_by_name("gitterHQ/services")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/google/google_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/google/google_provider_spec.rb
@@ -33,4 +33,18 @@ RSpec.describe DiscourseChatIntegration::Provider::GoogleProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "google",
+          data: {
+            name: "discourse",
+            webhook_url: "https://chat.googleapis.com/v1/abcdefg",
+          },
+        )
+      expect(described_class.get_channel_by_name("discourse")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/groupme/groupme_provider_spec.rb
@@ -39,4 +39,17 @@ RSpec.describe DiscourseChatIntegration::Provider::GroupmeProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "groupme",
+          data: {
+            groupme_instance_name: "my instance",
+          },
+        )
+      expect(described_class.get_channel_by_name("my instance")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/guilded/guilded_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/guilded/guilded_provider_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe DiscourseChatIntegration::Provider::GuildedProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "guilded",
+          data: {
+            name: "Awesome Channel",
+            webhook_url: "https://media.guilded.gg/webhooks/1234/abcd",
+          },
+        )
+      expect(described_class.get_channel_by_name("Awesome Channel")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/matrix/matrix_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/matrix/matrix_provider_spec.rb
@@ -44,4 +44,18 @@ RSpec.describe DiscourseChatIntegration::Provider::MatrixProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "matrix",
+          data: {
+            name: "Awesome Channel",
+            room_id: "!blah:matrix.org",
+          },
+        )
+      expect(described_class.get_channel_by_name("Awesome Channel")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/mattermost/mattermost_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/mattermost/mattermost_provider_spec.rb
@@ -57,4 +57,17 @@ RSpec.describe DiscourseChatIntegration::Provider::MattermostProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "mattermost",
+          data: {
+            identifier: "#awesomechannel",
+          },
+        )
+      expect(described_class.get_channel_by_name("#awesomechannel")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DiscourseChatIntegration::Provider::PowerAutomateProvider do
               "https://prod-189.westus.logic.azure.com:443/workflows/c94b462906e64fe8a7299043706be96e/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=-cmkg1oG-88dP3Yqdh62yTG1LUtJFcB91rQisorfw_w",
           },
         )
-      expect(described_class.get_channel_by_name("powerautomate")).to eq(expected)
+      expect(described_class.get_channel_by_name("discourse")).to eq(expected)
     end
   end
 end

--- a/spec/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider_spec.rb
@@ -34,4 +34,19 @@ RSpec.describe DiscourseChatIntegration::Provider::PowerAutomateProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "powerautomate",
+          data: {
+            name: "discourse",
+            webhook_url:
+              "https://prod-189.westus.logic.azure.com:443/workflows/c94b462906e64fe8a7299043706be96e/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=-cmkg1oG-88dP3Yqdh62yTG1LUtJFcB91rQisorfw_w",
+          },
+        )
+      expect(described_class.get_channel_by_name("powerautomate")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider_spec.rb
@@ -35,4 +35,17 @@ RSpec.describe DiscourseChatIntegration::Provider::RocketchatProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "rocketchat",
+          data: {
+            identifier: "#general",
+          },
+        )
+      expect(described_class.get_channel_by_name("#general")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/slack/slack_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/slack/slack_provider_spec.rb
@@ -346,4 +346,17 @@ RSpec.describe DiscourseChatIntegration::Provider::SlackProvider do
       }.to raise_error(StandardError)
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "slack",
+          data: {
+            identifier: "#general",
+          },
+        )
+      expect(described_class.get_channel_by_name("#general")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/teams/teams_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/teams/teams_provider_spec.rb
@@ -44,4 +44,19 @@ RSpec.describe DiscourseChatIntegration::Provider::TeamsProvider do
       end
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "teams",
+          data: {
+            name: "discourse",
+            webhook_url:
+              "https://outlook.office.com/webhook/677980e4-e03b-4a5e-ad29-dc1ee0c32a80@9e9b5238-5ab2-496a-8e6a-e9cf05c7eb5c/IncomingWebhook/e7a1006ded44478992769d0c4f391e34/e028ca8a-e9c8-4c6c-a4d8-578f881a3cff",
+          },
+        )
+      expect(described_class.get_channel_by_name("discourse")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "telegram",
+          data: {
+            name: "Awesome Channel",
+            chat_id: "123",
+          },
+        )
+      expect(described_class.get_channel_by_name("Awesome Channel")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/webex/webex_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/webex/webex_provider_spec.rb
@@ -34,4 +34,19 @@ RSpec.describe DiscourseChatIntegration::Provider::WebexProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      expected =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "webex",
+          data: {
+            name: "discourse",
+            webhook_url:
+              "https://webexapis.com/v1/webhooks/incoming/jAHJjVVQ1cgEwb4ikQQawIrGdUtlocKA9fSNvIyADQoYo0mI70pztWUDOu22gDRPJOEJtCsc688zi1RMa",
+          },
+        )
+      expect(described_class.get_channel_by_name("discourse")).to eq(expected)
+    end
+  end
 end

--- a/spec/lib/discourse_chat_integration/provider/zulip/zulip_provider_spec.rb
+++ b/spec/lib/discourse_chat_integration/provider/zulip/zulip_provider_spec.rb
@@ -42,4 +42,19 @@ RSpec.describe DiscourseChatIntegration::Provider::ZulipProvider do
       expect(stub1).to have_been_requested.once
     end
   end
+
+  describe ".get_channel_by_name" do
+    it "returns the right channel" do
+      created =
+        DiscourseChatIntegration::Channel.create!(
+          provider: "zulip",
+          data: {
+            stream: "foo",
+            subject: "Discourse Notifications",
+          },
+        )
+      channel = described_class.get_channel_by_name("foo")
+      expect(channel).to eq(created)
+    end
+  end
 end


### PR DESCRIPTION
This class works similarly to a post, but it is not a post.

Before merge needs https://github.com/discourse/discourse/pull/28714

This also adds `get_channel_by_name` to be used by every provider when the automation script requires it.

To help out with the migration, use `get_channel_name` 