### PR TITLE
FIX: adjust `full_url` method in `ChatIntegrationReferencePost` to return the correct URL

### DIFF
--- a/lib/discourse_chat_integration/chat_integration_reference_post.rb
+++ b/lib/discourse_chat_integration/chat_integration_reference_post.rb
@@ -24,7 +24,7 @@ module DiscourseChatIntegration
     end
 
     def full_url
-      @topic.posts.empty? ? @topic.full_url : @topic.posts.first.full_url
+      @topic.posts.empty? ? @topic.url : @topic.posts.first.full_url
     end
 
     def excerpt(maxlength = nil, options = {})

--- a/plugin.rb
+++ b/plugin.rb
@@ -105,8 +105,7 @@ after_initialize do
       script do |context, fields, automation|
         provider = fields.dig("provider", "value")
         channel_name = fields.dig("channel_name", "value")
-        puts "topic: #{context["topic"].url}"
-        puts "topic: #{context["topic"].relative_url}"
+
         post =
           DiscourseChatIntegration::ChatIntegrationReferencePost.new(
             user: context["user"],

--- a/plugin.rb
+++ b/plugin.rb
@@ -105,7 +105,8 @@ after_initialize do
       script do |context, fields, automation|
         provider = fields.dig("provider", "value")
         channel_name = fields.dig("channel_name", "value")
-
+        puts "topic: #{context["topic"].url}"
+        puts "topic: #{context["topic"].relative_url}"
         post =
           DiscourseChatIntegration::ChatIntegrationReferencePost.new(
             user: context["user"],

--- a/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
+++ b/spec/lib/discourse_chat_integration/chat_integration_reference_post_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
       context["removed_tags"] = %w[tag3 tag4]
     end
 
-    it "creates a post with the correct raw" do
+    it "creates a post with the correct .raw" do
       post =
         described_class.new(
           user: context["user"],
@@ -32,7 +32,7 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
       expect(post.raw).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
     end
 
-    it "has a working excerpt" do
+    it "has a working .excerpt" do
       post =
         described_class.new(
           user: context["user"],
@@ -44,6 +44,87 @@ RSpec.describe DiscourseChatIntegration::ChatIntegrationReferencePost do
           },
         )
       expect(post.excerpt).to eq("Added #tag1, #tag2 and removed #tag3, #tag4")
+    end
+
+    it "has a working .full_url" do
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: context["topic"],
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.full_url).to eq(topic.posts.first.full_url)
+
+      new_topic = Fabricate(:topic)
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: new_topic,
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.full_url).to eq(new_topic.url)
+    end
+
+    it "has a working .is_first_post?" do
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: context["topic"],
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.is_first_post?).to eq(false) # we had a post already
+
+      new_topic = Fabricate(:topic)
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: new_topic,
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.is_first_post?).to eq(true)
+    end
+
+    it "has a working .id" do
+      new_topic = Fabricate(:topic)
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: new_topic,
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.id).to eq(new_topic.id)
+
+      post =
+        described_class.new(
+          user: context["user"],
+          topic: context["topic"],
+          kind: context["kind"],
+          context: {
+            "added_tags" => context["added_tags"],
+            "removed_tags" => context["removed_tags"],
+          },
+        )
+      expect(post.id).to eq(first_post.id)
     end
   end
 end


### PR DESCRIPTION

Before it automation would fail because the topic does not have `full_url` method