### PR TITLE
FIX: Message triggering on topic creation

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -103,6 +103,10 @@ after_initialize do
       triggerables %i[topic_tags_changed]
 
       script do |context, fields, automation|
+        # DiscourseTagging.tag_topic_by_names runs on topic creation and on tags change
+        # we only want to send a message when tags change
+        next if context["topic"].new_record?
+
         provider = fields.dig("provider", "value")
         channel_name = fields.dig("channel_name", "value")
 

--- a/spec/integration/automation_spec.rb
+++ b/spec/integration/automation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Triggering notifications" do
     fab!(:admin)
     fab!(:category)
     fab!(:tag)
+    let(:valid_attrs) { Fabricate.attributes_for(:topic) }
 
     fab!(:automation) do
       Fabricate(
@@ -72,6 +73,15 @@ RSpec.describe "Triggering notifications" do
 
       DiscourseTagging.tag_topic_by_names(topic, Guardian.new(admin), [tag.name])
 
+      expect(validated_provider.sent_messages.length).to eq(0)
+    end
+
+    it "should not trigger a provider notification on topic creation for topic_tags_changed script" do
+      TopicCreator.create(
+        admin,
+        Guardian.new(admin),
+        valid_attrs.merge(tags: [tag.name], category: category.id),
+      )
       expect(validated_provider.sent_messages.length).to eq(0)
     end
   end


### PR DESCRIPTION
before topic tags changes trigger would fire on topic creation, now it only fires on tags changes