### PR TITLE
FIX: Automation `topic_tags_changed` should not fire on PMS

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -290,3 +290,5 @@ en:
               description: "You can find the channel name in the Chat Integration settings"
             provider:
               label: Provider
+            trigger_with_pms:
+              label: Trigger with PMs

--- a/plugin.rb
+++ b/plugin.rb
@@ -97,13 +97,16 @@ after_initialize do
             },
             required: true
       field :channel_name, component: :text, required: true
+      field :trigger_with_pms, component: :boolean
 
       version 1
 
       triggerables %i[topic_tags_changed]
 
       script do |context, fields, automation|
-        next if context["topic"].private_message?
+        if context["topic"].private_message?
+          next unless fields.dig("trigger_with_pms", "value")
+        end
 
         # DiscourseTagging.tag_topic_by_names runs on topic creation and on tags change
         # we only want to send a message when tags change

--- a/plugin.rb
+++ b/plugin.rb
@@ -103,6 +103,8 @@ after_initialize do
       triggerables %i[topic_tags_changed]
 
       script do |context, fields, automation|
+        next if context["topic"].private_message?
+
         # DiscourseTagging.tag_topic_by_names runs on topic creation and on tags change
         # we only want to send a message when tags change
         next if context["topic"].new_record?


### PR DESCRIPTION
automation on topic tags should not fire on PMS