### PR TITLE
FIX: Error modal not showing data

### DIFF
--- a/admin/assets/javascripts/admin/components/modal/channel-error.hbs
+++ b/admin/assets/javascripts/admin/components/modal/channel-error.hbs
@@ -1,4 +1,4 @@
 <DModal @closeModal={{@closeModal}} id="chat_integration_error_modal">
-  <h4>{{i18n @model.error_key}}</h4>
-  <pre>{{@model.error_info}}</pre>
+  <h4>{{i18n @model.channel.error_key}}</h4>
+  <pre>{{@model.channel.error_info}}</pre>
 </DModal>


### PR DESCRIPTION
Before, there was an issue where the error modal was not showing the data. This was because the error modal was not being shown when there were errors.

before: 

https://github.com/user-attachments/assets/0886277a-2aea-4655-8efa-63736bd35899


now:  

https://github.com/user-attachments/assets/62334db9-f742-4189-881b-781720c92438

