### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20211202120030_add_unique_index_to_slack_thread_ts.rb
+++ b/db/migrate/20211202120030_add_unique_index_to_slack_thread_ts.rb
@@ -8,4 +8,8 @@ class AddUniqueIndexToSlackThreadTs < ActiveRecord::Migration[6.1]
               where: "(name LIKE 'slack_thread_id_%')",
               name: "index_topic_custom_fields_on_topic_id_and_slack_thread_id"
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.

