### PR TITLE
FIX: Update flaky test in showing error modal

### DIFF
--- a/spec/system/create_channel_spec.rb
+++ b/spec/system/create_channel_spec.rb
@@ -32,23 +32,23 @@ RSpec.describe "Create channel", type: :system do
     expect(find(".channel-info")).to have_content("bloop")
   end
 
-  it "shows error in chanel modal" do
+  it "shows the error in the channel modal" do
     DiscourseChatIntegration::Rule.create!(
       channel: chan1,
       filter: "watch",
       category_id: category.id,
     )
 
-    visit("/admin/plugins/chat-integration/dummy")
-
     provider.set_raise_exception(
       DiscourseChatIntegration::ProviderError.new info: { error_key: "hello" }
     )
     manager.trigger_notifications(first_post.id)
+
+    visit("/admin/plugins/chat-integration/dummy")
+
     expect(find(".error-message")).to have_content(
       I18n.t("js.chat_integration.channels_with_errors"),
     )
-
     find(".channel-title").find("button").click
     expect(page).to have_content "{\n  \"error_key\": \"hello\"\n}"
   end


### PR DESCRIPTION
the error:

```
Randomized with seed 43756
.F

Failures:

  1) Create channel shows error in chanel modal
     Failure/Error: super

     Capybara::ElementNotFound:
       Unable to find css ".error-message"

     [Screenshot Image]: /var/www/discourse/tmp/capybara/failures_r_spec_example_groups_create_channel_shows_error_in_chanel_modal_523.png

     ~~~~~~~ JS LOGS ~~~~~~~
     (no logs)
```

To try solving this, I've changed the ordering, before visiting the page I already set up the channel error.