### PR TITLE
Changed "Message." to "Message" in client.en.yml

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -271,7 +271,7 @@ en:
           title: Send Slack message
           fields:
             message:
-              label: Message.
+              label: Message
               description: >-
                            Use ${TOPIC} for topic name, ${URL} for used URL, ${REMOVED_TAGS} for removed tags, ${ADDED_TAGS} for added tags,
                            ${ADDED_AND_REMOVED} for default text.


### PR DESCRIPTION
Translators pointed out there is a stray period at the end of a label for a setting for sending slack messages,  so I removed it.