### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/admin/assets/javascripts/admin/components/channel-details.hbs
+++ b/admin/assets/javascripts/admin/components/channel-details.hbs
@@ -2,7 +2,7 @@
   <div class="channel-header">
     <div class="pull-right">
       <DButton
-        @icon="pencil-alt"
+        @icon="pencil"
         @title="chat_integration.edit_channel"
         @label="chat_integration.edit_channel"
         @action={{fn @editChannel @channel}}
@@ -17,7 +17,7 @@
       />
 
       <DButton
-        @icon="trash-alt"
+        @icon="trash-can"
         @title="chat_integration.delete_channel"
         @label="chat_integration.delete_channel"
         @action={{fn this.deleteChannel @channel}}
@@ -28,7 +28,7 @@
     <span class="channel-title">
       {{#if @channel.error_key}}
         <DButton
-          @icon="exclamation-triangle"
+          @icon="triangle-exclamation"
           @action={{fn @showError @channel}}
           class="delete btn-danger"
         />

--- a/admin/assets/javascripts/admin/components/rule-row.hbs
+++ b/admin/assets/javascripts/admin/components/rule-row.hbs
@@ -29,14 +29,14 @@
 
   <td>
     <DButton
-      @icon="pencil-alt"
+      @icon="pencil"
       @title="chat_integration.rule_table.edit_rule"
       @action={{fn @edit @rule}}
       class="edit"
     />
 
     <DButton
-      @icon="far-trash-alt"
+      @icon="far-trash-can"
       @title="chat_integration.rule_table.delete_rule"
       @action={{fn this.delete @rule}}
       class="delete"

--- a/admin/assets/javascripts/admin/templates/plugins-chat-integration.hbs
+++ b/admin/assets/javascripts/admin/templates/plugins-chat-integration.hbs
@@ -17,7 +17,7 @@
     </div>
 
     <DButton
-      @icon="cog"
+      @icon="gear"
       @title="chat_integration.settings"
       @label="chat_integration.settings"
       @action={{route-action "showSettings"}}


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.