### PR TITLE
DEV: update deprecated icon names exclamation-circle and times-circle

### DIFF
--- a/admin/assets/javascripts/admin/models/rule.js
+++ b/admin/assets/javascripts/admin/models/rule.js
@@ -41,7 +41,7 @@ export default class Rule extends RestModel {
       {
         id: "watch",
         name: I18n.t("chat_integration.filter.watch"),
-        icon: "exclamation-circle",
+        icon: "circle-exclamation",
       },
       {
         id: "follow",
@@ -51,7 +51,7 @@ export default class Rule extends RestModel {
       {
         id: "mute",
         name: I18n.t("chat_integration.filter.mute"),
-        icon: "times-circle",
+        icon: "circle-xmark",
       }
     );
 


### PR DESCRIPTION
This PR updates the deprecated `exclamation-circle` and `times-circle` icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.