### PR TITLE
FIX: Topic changing category was not triggering notifications

### DIFF
--- a/app/services/manager.rb
+++ b/app/services/manager.rb
@@ -15,10 +15,10 @@ module DiscourseChatIntegration
       # Abort if the post is blank
       return if post.blank?
 
-      # Abort if post is not either regular or a 'category_changed' small action
+      # Abort if post is not either regular or a 'category_changed' whisper
       if (post.post_type != Post.types[:regular]) &&
            !(
-             post.post_type == Post.types[:small_action] &&
+             post.post_type == Post.types[:whisper] &&
                %w[category_changed].include?(post.action_code)
            )
         return


### PR DESCRIPTION
We [moved](https://github.com/discourse/discourse/pull/29602/files) `category_changed` notification to be a `whisper` but we forgot to update the check in `manager.rb` to verify not for a `small_post` but for a whisper.

Added a test to cover this case.